### PR TITLE
Add Goli date cast and helper trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,46 @@ Key capabilities include:
 - seamless Carbon interoperability for chained date operations
 - resolving new instances through the Laravel container using the `goli` binding
 
+### Casting Eloquent attributes to Jalali-aware objects
+
+For database columns that should automatically become `Goli` instances you can use the built-in cast and helper trait.
+
+```php
+use Efati\ModuleGenerator\Support\HasGoliDates;
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    use HasGoliDates;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $goliDates = [
+        'published_at',
+        'published_until',
+    ];
+}
+
+$article = Article::make([
+    'title' => 'New year announcement',
+    // Both Jalali and Gregorian values are accepted thanks to the cast
+    'published_at' => '1403-01-01 10:00:00',
+]);
+
+$article->published_at->toJalaliDateString();     // 1403-01-01
+$article->published_at->formatGregorian('Y-m-d');  // 2024-03-20
+```
+
+The trait automatically pushes the cast to the `$casts` array during model construction. If you need to register casts at
+runtime (for instance in a constructor), call `$model->addGoliDateCast('starts_at', 'ends_at');`.
+
+To see a few round-trip examples you can run the included script:
+
+```bash
+php tests/goli-date-cast.php
+```
+
 ---
 
 ## Version History

--- a/src/Casts/GoliDateCast.php
+++ b/src/Casts/GoliDateCast.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Efati\ModuleGenerator\Casts;
+
+use Efati\ModuleGenerator\Support\Goli;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class GoliDateCast implements CastsAttributes
+{
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  mixed  $value
+     * @return Goli|null
+     */
+    public function get($model, string $key, $value, array $attributes): ?Goli
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof Goli) {
+            return $value;
+        }
+
+        return Goli::instance($value);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  mixed  $value
+     * @return array<string, mixed>|string|null
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $instance = $value instanceof Goli ? $value : Goli::instance($value);
+
+        $format = method_exists($model, 'getDateFormat') ? $model->getDateFormat() : 'Y-m-d H:i:s';
+
+        return $instance->formatGregorian($format);
+    }
+}

--- a/src/Support/HasGoliDates.php
+++ b/src/Support/HasGoliDates.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Efati\ModuleGenerator\Support;
+
+use Efati\ModuleGenerator\Casts\GoliDateCast;
+
+trait HasGoliDates
+{
+    /**
+     * Register the configured Jalali date casts on model initialisation.
+     */
+    protected function initializeHasGoliDates(): void
+    {
+        foreach ($this->goliDateCastAttributes() as $attribute) {
+            $this->casts[$attribute] = GoliDateCast::class;
+        }
+    }
+
+    /**
+     * Resolve the list of attributes that should be converted into Goli instances.
+     *
+     * @return array<int, string>
+     */
+    protected function goliDateCastAttributes(): array
+    {
+        $attributes = [];
+
+        if (property_exists($this, 'goliDates')) {
+            $configured = $this->goliDates;
+
+            if (is_array($configured)) {
+                $attributes = $configured;
+            } elseif (is_string($configured) && $configured !== '') {
+                $attributes = [$configured];
+            }
+        }
+
+        $attributes = array_filter($attributes, static fn ($value) => is_string($value) && $value !== '');
+
+        return array_values(array_unique($attributes));
+    }
+
+    /**
+     * Merge new attributes into the cast list at runtime.
+     */
+    public function addGoliDateCast(string ...$attributes): void
+    {
+        foreach ($attributes as $attribute) {
+            if ($attribute === '') {
+                continue;
+            }
+
+            $this->casts[$attribute] = GoliDateCast::class;
+        }
+    }
+}

--- a/tests/goli-date-cast.php
+++ b/tests/goli-date-cast.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Efati\ModuleGenerator\Casts\GoliDateCast;
+use Efati\ModuleGenerator\Support\Goli;
+use Efati\ModuleGenerator\Support\HasGoliDates;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (! interface_exists(\Illuminate\Contracts\Database\Eloquent\CastsAttributes::class)) {
+    require __DIR__ . '/stubs/CastsAttributes.php';
+}
+
+if (! class_exists(Carbon::class)) {
+    fwrite(STDERR, "The Carbon dependency is required. Run 'composer install' inside the package before executing this script." . PHP_EOL);
+
+    exit(1);
+}
+
+class SampleEvent
+{
+    use HasGoliDates;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $casts = [];
+
+    protected $table = 'sample_events';
+    public $timestamps = false;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $goliDates = ['scheduled_at'];
+
+    public function __construct()
+    {
+        $this->initializeHasGoliDates();
+    }
+
+    public function getDateFormat(): string
+    {
+        return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * @return array<string, class-string>
+     */
+    public function getCasts(): array
+    {
+        return $this->casts;
+    }
+}
+
+$cast = new GoliDateCast();
+$model = new SampleEvent();
+
+assertCastRegistered($model, 'scheduled_at');
+
+$cases = [
+    'gregorian-string' => '2024-03-20 10:15:00',
+    'carbon-instance' => Carbon::create(2024, 3, 21, 0, 0, 0, 'Asia/Tehran'),
+    'jalali-string' => '1403-01-02 08:30:45',
+    'jalali-array' => [
+        'year' => 1402,
+        'month' => 12,
+        'day' => 29,
+        'hour' => 23,
+        'minute' => 59,
+        'second' => 59,
+    ],
+    'goli-instance' => Goli::parseJalali('1403-01-05 18:00:00'),
+];
+
+foreach ($cases as $label => $input) {
+    $expected = Goli::instance($input)->formatGregorian($model->getDateFormat());
+
+    $stored = $cast->set($model, 'scheduled_at', $input, ['scheduled_at' => null]);
+
+    if ($stored !== $expected) {
+        throw new RuntimeException(sprintf(
+            'Case "%s" failed when storing. Expected %s, got %s',
+            $label,
+            $expected,
+            (string) $stored
+        ));
+    }
+
+    $retrieved = $cast->get($model, 'scheduled_at', $stored, ['scheduled_at' => $stored]);
+
+    if (! $retrieved instanceof Goli) {
+        throw new RuntimeException(sprintf('Case "%s" did not return a Goli instance.', $label));
+    }
+
+    $roundTrip = $retrieved->formatGregorian($model->getDateFormat());
+
+    if ($roundTrip !== $expected) {
+        throw new RuntimeException(sprintf(
+            'Case "%s" failed round trip. Expected %s, got %s',
+            $label,
+            $expected,
+            $roundTrip
+        ));
+    }
+}
+
+if ($cast->set($model, 'scheduled_at', null, []) !== null) {
+    throw new RuntimeException('Null values should persist as null.');
+}
+
+if ($cast->get($model, 'scheduled_at', null, []) !== null) {
+    throw new RuntimeException('Null database values should return null.');
+}
+
+$model->addGoliDateCast('starts_at');
+assertCastRegistered($model, 'starts_at');
+
+echo "All Goli date cast assertions passed." . PHP_EOL;
+
+function assertCastRegistered(object $model, string $key): void
+{
+    $casts = $model->getCasts();
+
+    if (($casts[$key] ?? null) !== GoliDateCast::class) {
+        throw new RuntimeException(sprintf('Cast for "%s" is missing on %s.', $key, $model::class));
+    }
+}

--- a/tests/stubs/CastsAttributes.php
+++ b/tests/stubs/CastsAttributes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+if (! interface_exists(CastsAttributes::class, false)) {
+    interface CastsAttributes
+    {
+        /**
+         * @param  mixed  $value
+         * @return mixed
+         */
+        public function get($model, string $key, $value, array $attributes);
+
+        /**
+         * @param  mixed  $value
+         * @return mixed
+         */
+        public function set($model, string $key, $value, array $attributes);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `GoliDateCast` so Eloquent attributes hydrate into `Goli` value objects and persist using the model date format
- introduce a `HasGoliDates` trait that registers the cast from a `$goliDates` list and supports runtime additions
- document the new cast/trait usage in the README and add a standalone script that round-trips several Jalali/Gregorian dates

## Testing
- `php tests/goli-date-cast.php` *(fails: Carbon dependency missing until composer install)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4a4aec74832181836c9bdf6524e0