### PR TITLE
Add schema-aware generation via --fields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ php artisan make:module ModelName [options]
 | `--no-test`           | Skip Feature Test generation |
 | `--no-provider`       | Skip provider creation and auto-registration |
 | `--force`             | Overwrite existing files (default is to skip and warn) |
+| `--fields=`           | Inline schema definition so generators can infer fillable fields, validation rules, and test payloads before the Eloquent model exists |
 
 ### Short aliases
 
@@ -100,6 +101,36 @@ This will generate:
 - **Feature Tests**: `tests/Feature/ProductCrudTest.php`
 
 > Tip: rerunning the generator without `--force` will skip existing files and list the skipped paths in the console output.
+
+### Schema option (`--fields`)
+
+When you run the command before creating the actual Eloquent model, you can describe the schema inline so DTOs, FormRequests, Resources, and Feature tests know which attributes to work with:
+
+```bash
+php artisan make:module Product \
+  --api --requests --tests \
+  --fields="title:string:unique, price:decimal(8,2):nullable, is_active:boolean, category_id:foreignId:nullable:fk=categories.id"
+```
+
+The syntax is a comma-separated list of field definitions using `name:type[:modifier[:modifier...]]`. Modifiers can also be separated with spaces or pipes (`|`). The supported modifiers are:
+
+- `nullable` – marks the field as optional (`required` is assumed otherwise)
+- `unique` – adds unique validation to the generated FormRequests
+- `fk=table.column` – adds a foreign key rule (`fk=table` defaults the column to `id`)
+
+Supported types (aliases are allowed, e.g. `foreignId` → `integer`):
+
+- `string`, `text`
+- `integer` (int, bigInteger, foreignId, etc.)
+- `numeric` / `decimal` / `float` / `double`
+- `boolean`
+- `date`, `datetime`
+- `json`, `array`
+- `uuid`
+- `email`
+- `url`
+
+Parentheses are ignored when normalising the type, so `decimal(8,2)` will still map to a numeric rule. The schema is used as a fallback whenever the generator cannot read fillable fields from an actual model class.
 
 ---
 

--- a/src/Generators/DTOGenerator.php
+++ b/src/Generators/DTOGenerator.php
@@ -3,10 +3,11 @@
 namespace Efati\ModuleGenerator\Generators;
 
 use Illuminate\Support\Facades\File;
+use Efati\ModuleGenerator\Support\SchemaParser;
 
 class DTOGenerator
 {
-    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false): array
+    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false, array $schema = []): array
     {
         $paths = config('module-generator.paths', []);
         $dtoRel = $paths['dto'] ?? ($paths['dtos'] ?? 'DTOs');
@@ -18,20 +19,26 @@ class DTOGenerator
         $filePath  = $dtoPath . "/{$className}.php";
 
         $modelFqcn = "{$baseNamespace}\\Models\\{$name}";
-        $fillable  = self::getFillable($modelFqcn);
+        $fillable  = self::getFillable($modelFqcn, $schema);
 
         $content   = self::build($className, $baseNamespace, $fillable);
 
         return [$filePath => self::writeFile($filePath, $content, $force)];
     }
 
-    private static function getFillable(string $modelFqcn): array
+    private static function getFillable(string $modelFqcn, array $schema): array
     {
         if (!class_exists($modelFqcn)) {
-            return [];
+            return SchemaParser::fieldNames($schema);
         }
         $model = new $modelFqcn();
-        return method_exists($model, 'getFillable') ? $model->getFillable() : [];
+        $fillable = method_exists($model, 'getFillable') ? $model->getFillable() : [];
+
+        if (empty($fillable)) {
+            return SchemaParser::fieldNames($schema);
+        }
+
+        return $fillable;
     }
 
     private static function build(string $className, string $baseNamespace, array $fillable): string

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -4,10 +4,11 @@ namespace Efati\ModuleGenerator\Generators;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Efati\ModuleGenerator\Support\SchemaParser;
 
 class FormRequestGenerator
 {
-    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false): array
+    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false, array $schema = []): array
     {
         $paths  = config('module-generator.paths', []);
         $reqRel = $paths['form_request'] ?? ($paths['requests'] ?? 'Http/Requests');
@@ -19,7 +20,7 @@ class FormRequestGenerator
         $table      = self::guessTable($modelFqcn);
         $routeParam = lcfirst($name);
 
-        [$storeRules, $updateRules] = self::buildRules($modelFqcn, $table);
+        [$storeRules, $updateRules] = self::buildRules($modelFqcn, $table, $schema);
 
         $storeContent  = self::buildRequestClass('Store' . $name . 'Request', $baseNamespace, $storeRules, false, null, null);
         $updateContent = self::buildRequestClass('Update' . $name . 'Request', $baseNamespace, $updateRules, true, $routeParam, $table);
@@ -45,7 +46,7 @@ class FormRequestGenerator
         return Str::snake(Str::pluralStudly(class_basename($modelFqcn)));
     }
 
-    private static function buildRules(string $modelFqcn, string $table): array
+    private static function buildRules(string $modelFqcn, string $table, array $schema): array
     {
         $fillable = [];
         if (class_exists($modelFqcn)) {
@@ -53,23 +54,40 @@ class FormRequestGenerator
             $fillable = method_exists($m, 'getFillable') ? $m->getFillable() : [];
         }
 
+        if (empty($fillable)) {
+            $fillable = SchemaParser::fieldNames($schema);
+        }
+
+        $schemaMap = SchemaParser::keyByName($schema);
+
         $store = [];
         foreach ($fillable as $f) {
-            $store[$f] = implode('|', self::inferRuleForField($f, $table, true));
+            $definition = $schemaMap[$f] ?? null;
+            $rules      = self::inferRuleForField($f, $table, true, $definition);
+            if (!empty($rules)) {
+                $store[$f] = implode('|', $rules);
+            }
         }
 
         $update = [];
         foreach ($fillable as $f) {
-            $r = self::inferRuleForField($f, $table, false);
-            array_unshift($r, 'sometimes');
-            $update[$f] = implode('|', $r);
+            $definition = $schemaMap[$f] ?? null;
+            $r          = self::inferRuleForField($f, $table, false, $definition);
+            if (!empty($r)) {
+                array_unshift($r, 'sometimes');
+                $update[$f] = implode('|', $r);
+            }
         }
 
         return [$store, $update];
     }
 
-    private static function inferRuleForField(string $field, string $table, bool $forCreate): array
+    private static function inferRuleForField(string $field, string $table, bool $forCreate, ?array $definition = null): array
     {
+        if ($definition !== null) {
+            return self::rulesFromDefinition($field, $table, $definition);
+        }
+
         if (Str::endsWith($field, '_id')) {
             $base    = substr($field, 0, -3);
             $fkTable = Str::snake(Str::pluralStudly($base));
@@ -97,6 +115,55 @@ class FormRequestGenerator
             return ['nullable', 'numeric'];
         }
         return ['nullable'];
+    }
+
+    private static function rulesFromDefinition(string $field, string $table, array $definition): array
+    {
+        $nullable = (bool) ($definition['nullable'] ?? false);
+        $rules    = [$nullable ? 'nullable' : 'required'];
+
+        $typeRules = self::rulesForType((string) ($definition['type'] ?? 'string'));
+        if (!empty($typeRules)) {
+            $rules = array_merge($rules, $typeRules);
+        }
+
+        if (!empty($definition['unique'])) {
+            $rules[] = 'unique:' . $table . ',' . $field;
+        }
+
+        if (!empty($definition['foreign']) && is_array($definition['foreign'])) {
+            $fkTable  = $definition['foreign']['table'] ?? null;
+            $fkColumn = $definition['foreign']['column'] ?? 'id';
+            if ($fkTable) {
+                $rules[] = 'exists:' . $fkTable . ',' . $fkColumn;
+            }
+        } elseif (Str::endsWith($field, '_id')) {
+            $base    = substr($field, 0, -3);
+            $fkTable = Str::snake(Str::pluralStudly($base));
+            $rules[] = 'exists:' . $fkTable . ',id';
+        }
+
+        return array_values(array_unique($rules));
+    }
+
+    private static function rulesForType(string $type): array
+    {
+        $type = SchemaParser::normalizeType($type);
+
+        return match ($type) {
+            'string' => ['string', 'max:255'],
+            'text' => ['string'],
+            'integer' => ['integer'],
+            'numeric' => ['numeric'],
+            'boolean' => ['boolean'],
+            'date' => ['date'],
+            'datetime' => ['date'],
+            'json', 'array' => ['array'],
+            'uuid' => ['uuid'],
+            'email' => ['email', 'max:255'],
+            'url' => ['url'],
+            default => [],
+        };
     }
 
     private static function buildRequestClass(

--- a/src/Generators/ResourceGenerator.php
+++ b/src/Generators/ResourceGenerator.php
@@ -4,10 +4,11 @@ namespace Efati\ModuleGenerator\Generators;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Efati\ModuleGenerator\Support\SchemaParser;
 
 class ResourceGenerator
 {
-    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false): array
+    public static function generate(string $name, string $baseNamespace = 'App', bool $force = false, array $schema = []): array
     {
         $paths = config('module-generator.paths', []);
         $resourceRel = $paths['resource'] ?? ($paths['resources'] ?? 'Http/Resources');
@@ -21,7 +22,7 @@ class ResourceGenerator
         $modelFqcn  = "{$baseNamespace}\\Models\\{$name}";
         $helperFqcn = "{$baseNamespace}\\Helpers\\StatusHelper";
 
-        $fillable   = self::getFillable($modelFqcn);
+        $fillable   = self::getFillable($modelFqcn, $schema);
         $relations  = self::detectRelations($modelFqcn);
 
         $content    = self::build($className, $baseNamespace, $helperFqcn, $fillable, $relations);
@@ -29,11 +30,19 @@ class ResourceGenerator
         return [$filePath => self::writeFile($filePath, $content, $force)];
     }
 
-    private static function getFillable(string $modelFqcn): array
+    private static function getFillable(string $modelFqcn, array $schema): array
     {
-        if (!class_exists($modelFqcn)) return [];
-        $m = new $modelFqcn();
-        return method_exists($m, 'getFillable') ? $m->getFillable() : [];
+        if (!class_exists($modelFqcn)) {
+            return SchemaParser::fieldNames($schema);
+        }
+        $m        = new $modelFqcn();
+        $fillable = method_exists($m, 'getFillable') ? $m->getFillable() : [];
+
+        if (empty($fillable)) {
+            return SchemaParser::fieldNames($schema);
+        }
+
+        return $fillable;
     }
 
     private static function detectRelations(string $modelFqcn): array

--- a/src/Support/SchemaParser.php
+++ b/src/Support/SchemaParser.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Efati\ModuleGenerator\Support;
+
+class SchemaParser
+{
+    /**
+     * Parse a CLI schema string into an array of field definitions.
+     *
+     * Each definition supports the syntax:
+     *   name:type[:modifier[:modifier ...]]
+     * Modifiers can be provided using ":", "|" or spaces as separators.
+     * Supported modifiers: nullable, unique, fk=table.column
+     *
+     * @return array<int, array{name: string, type: string, nullable: bool, unique: bool, foreign: array{table: string, column: string}|null}>
+     */
+    public static function parse(string $input): array
+    {
+        $definitions = self::splitDefinitions($input);
+        $fields      = [];
+
+        foreach ($definitions as $definition) {
+            $field = self::parseField($definition);
+            if ($field === null) {
+                continue;
+            }
+            $fields[] = $field;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Extract only the field names from a schema array.
+     *
+     * @param  array<int, array{name: string}>  $schema
+     * @return array<int, string>
+     */
+    public static function fieldNames(array $schema): array
+    {
+        $names = [];
+        foreach ($schema as $field) {
+            if (!isset($field['name'])) {
+                continue;
+            }
+            $names[] = (string) $field['name'];
+        }
+
+        return $names;
+    }
+
+    /**
+     * Key the schema array by field name for faster lookups.
+     *
+     * @param  array<int, array{name: string}>  $schema
+     * @return array<string, array{name: string, type: string, nullable: bool, unique: bool, foreign: array{table: string, column: string}|null}>
+     */
+    public static function keyByName(array $schema): array
+    {
+        $assoc = [];
+        foreach ($schema as $field) {
+            if (!isset($field['name'])) {
+                continue;
+            }
+            $assoc[(string) $field['name']] = $field;
+        }
+
+        return $assoc;
+    }
+
+    /**
+     * Convert a raw type string into a canonical type.
+     */
+    public static function normalizeType(string $type): string
+    {
+        $type = trim($type);
+        if ($type === '') {
+            return 'string';
+        }
+
+        $type = strtolower($type);
+        $type = preg_replace('/\s+/', '', $type) ?? $type;
+        $type = preg_replace('/\(.*$/', '', $type) ?? $type;
+
+        return match ($type) {
+            'char', 'varchar', 'string' => 'string',
+            'text', 'mediumtext', 'longtext' => 'text',
+            'int', 'integer', 'bigint', 'biginteger', 'mediumint', 'smallint', 'tinyint',
+            'unsignedint', 'unsignedinteger', 'unsignedbigint', 'unsignedbiginteger',
+            'unsignedmediumint', 'unsignedsmallint', 'unsignedtinyint',
+            'increments', 'bigincrements', 'foreignid', 'foreignkey' => 'integer',
+            'decimal', 'double', 'float', 'numeric' => 'numeric',
+            'bool', 'boolean' => 'boolean',
+            'date' => 'date',
+            'datetime', 'datetimetz', 'timestamp', 'timestamptz' => 'datetime',
+            'json', 'jsonb' => 'json',
+            'array' => 'array',
+            'uuid' => 'uuid',
+            'email' => 'email',
+            'url' => 'url',
+            default => $type,
+        };
+    }
+
+    /**
+     * Split the CLI string into individual field definitions while respecting parentheses.
+     *
+     * @return array<int, string>
+     */
+    private static function splitDefinitions(string $input): array
+    {
+        $input = trim($input);
+        if ($input === '') {
+            return [];
+        }
+
+        $items  = [];
+        $buffer = '';
+        $depth  = 0;
+        $len    = strlen($input);
+
+        for ($i = 0; $i < $len; $i++) {
+            $char = $input[$i];
+
+            if ($char === '(') {
+                $depth++;
+                $buffer .= $char;
+                continue;
+            }
+
+            if ($char === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+                $buffer .= $char;
+                continue;
+            }
+
+            if ($char === ',' && $depth === 0) {
+                $trimmed = trim($buffer);
+                if ($trimmed !== '') {
+                    $items[] = $trimmed;
+                }
+                $buffer = '';
+                continue;
+            }
+
+            $buffer .= $char;
+        }
+
+        $trimmed = trim($buffer);
+        if ($trimmed !== '') {
+            $items[] = $trimmed;
+        }
+
+        return $items;
+    }
+
+    /**
+     * Parse an individual field definition.
+     *
+     * @return array{name: string, type: string, nullable: bool, unique: bool, foreign: array{table: string, column: string}|null}|null
+     */
+    private static function parseField(string $definition): ?array
+    {
+        $definition = trim($definition);
+        if ($definition === '') {
+            return null;
+        }
+
+        $name = $definition;
+        $rest = '';
+
+        $colonPos = strpos($definition, ':');
+        if ($colonPos !== false) {
+            $name = substr($definition, 0, $colonPos);
+            $rest = substr($definition, $colonPos + 1);
+        }
+
+        $name = trim((string) $name);
+        if ($name === '') {
+            return null;
+        }
+
+        [$type, $modifiers] = self::splitTypeAndModifiers($rest);
+
+        $nullable = false;
+        $unique   = false;
+        $foreign  = null;
+
+        foreach ($modifiers as $modifier) {
+            $lower = strtolower($modifier);
+
+            if ($lower === '') {
+                continue;
+            }
+
+            if (in_array($lower, ['nullable', 'null', 'optional'], true)) {
+                $nullable = true;
+                continue;
+            }
+
+            if (in_array($lower, ['required', 'notnull', 'not-null'], true)) {
+                $nullable = false;
+                continue;
+            }
+
+            if (in_array($lower, ['unique', 'uniq'], true)) {
+                $unique = true;
+                continue;
+            }
+
+            if (preg_match('/^(?:fk|foreign|references)\s*(?:=|\()\s*(.+?)\s*\)?$/i', $modifier, $matches)) {
+                $foreign = self::parseForeign($matches[1]);
+                continue;
+            }
+        }
+
+        return [
+            'name'     => $name,
+            'type'     => self::normalizeType($type),
+            'nullable' => $nullable,
+            'unique'   => $unique,
+            'foreign'  => $foreign,
+        ];
+    }
+
+    /**
+     * Split the "type[:modifiers]" segment into a type and modifier tokens.
+     *
+     * @return array{0: string, 1: array<int, string>}
+     */
+    private static function splitTypeAndModifiers(string $segment): array
+    {
+        $segment = trim($segment);
+        if ($segment === '') {
+            return ['string', []];
+        }
+
+        $len  = strlen($segment);
+        $type = '';
+        $i    = 0;
+
+        while ($i < $len) {
+            $char = $segment[$i];
+            if (str_contains(':|, ?!\t', $char)) {
+                break;
+            }
+            $type .= $char;
+            $i++;
+        }
+
+        if ($type === '') {
+            $type = 'string';
+        }
+
+        $remaining = substr($segment, $i);
+        $remaining = ltrim($remaining, " :|,?!\t");
+
+        if ($remaining === '' || $remaining === false) {
+            return [$type, []];
+        }
+
+        $tokens = preg_split('/[:|,\s]+/', $remaining) ?: [];
+        $tokens = array_filter(array_map('trim', $tokens), fn($token) => $token !== '');
+
+        return [$type, array_values($tokens)];
+    }
+
+    /**
+     * Parse the FK value into table/column.
+     *
+     * @return array{table: string, column: string}|null
+     */
+    private static function parseForeign(?string $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value, " \t\n\r\0\x0B(){}");
+        if ($value === '') {
+            return null;
+        }
+
+        $value = str_replace(':', '.', $value);
+        $parts = array_values(array_filter(explode('.', $value), fn($part) => $part !== ''));
+        if (empty($parts)) {
+            return null;
+        }
+
+        $table  = $parts[0];
+        $column = $parts[1] ?? 'id';
+
+        return [
+            'table'  => $table,
+            'column' => $column,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a `--fields` option to `make:module` and parse inline schema definitions
- reuse the parsed schema in the DTO, Resource, FormRequest and Test generators when a model class is missing
- document the schema syntax and supported field types in the README

## Testing
- composer dump-autoload
- php -l src/Support/SchemaParser.php
- php -l src/Generators/TestGenerator.php
- php -l src/Generators/FormRequestGenerator.php
- php -l src/Generators/ResourceGenerator.php
- php -l src/Generators/DTOGenerator.php
- php -l src/Commands/MakeModuleCommand.php

------
https://chatgpt.com/codex/tasks/task_e_68cd4b69abb08321a9abf65aff92bd8a