### PR TITLE
Refactor generators to use publishable stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ This will create `config/module-generator.php` where you can adjust:
 - **Default controller path** (e.g., `App\Http\Controllers\Api\V1`)
 - **Enable/Disable** generation of tests, form requests, DTOs, etc.
 
+### Customising generator stubs
+
+If your team follows specific coding standards you can publish and edit the generator stubs:
+
+```bash
+php artisan vendor:publish --tag=module-generator-stubs
+```
+
+All stub files will be copied to `resources/stubs/module-generator`. The generators always look for a published stub first, so
+any changes you make there (naming conventions, imports, method bodies, docblocks, etc.) will be reflected in the next
+generation run. The package uses simple placeholders such as `{{ namespace }}`, `{{ class }}` or `{{ store_argument }}` inside
+the stub files—leave these intact and only change the surrounding structure to keep the dynamic parts working.
+
 ---
 
 ## Usage

--- a/src/Generators/DTOGenerator.php
+++ b/src/Generators/DTOGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 
 class DTOGenerator
@@ -38,56 +39,35 @@ class DTOGenerator
     {
         $ns = "{$baseNamespace}\\DTOs";
 
-        $props = [];
-        $ctor  = [];
-        $asg   = [];
+        $properties = [];
+        $constructorSignature = [];
+        $constructorBody = [];
+
         foreach ($fillable as $f) {
-            $props[] = "    public mixed \${$f};";
-            $ctor[]  = "        mixed \${$f} = null";
-            $asg[]   = "        \$this->{$f} = \${$f};";
+            $properties[] = "    public mixed \${$f};";
+            $constructorSignature[] = "        mixed \${$f} = null";
+            $constructorBody[] = "        \$this->{$f} = \${$f};";
         }
 
-        $ctorSig = implode(",\n", $ctor);
-        $asgBody = implode("\n", $asg);
-
-        $fromReq = [];
+        $fromRequestBody = [];
         foreach ($fillable as $f) {
-            $fromReq[] = "            \$dto->{$f} = \$request->input('{$f}');";
+            $fromRequestBody[] = "            \$dto->{$f} = \$request->input('{$f}');";
         }
-        $fromReqBody = implode("\n", $fromReq);
 
-        $toArray = empty($fillable) ? '' : implode("\n", array_map(fn($f) => "        if (\$this->{$f} !== null) { \$out['{$f}'] = \$this->{$f}; }", $fillable));
+        $toArrayBody = [];
+        foreach ($fillable as $f) {
+            $toArrayBody[] = "        if (\$this->{$f} !== null) { \$out['{$f}'] = \$this->{$f}; }";
+        }
 
-        return "<?php
-
-namespace {$ns};
-
-use Illuminate\\Http\\Request;
-
-class {$className}
-{
-" . (empty($props) ? '' : implode("\n", $props) . "\n") . "
-    public function __construct(
-{$ctorSig}
-    ) {
-{$asgBody}
-    }
-
-    public static function fromRequest(Request \$request): self
-    {
-        \$dto = new self();
-{$fromReqBody}
-        return \$dto;
-    }
-
-    public function toArray(): array
-    {
-        \$out = [];
-{$toArray}
-        return \$out;
-    }
-}
-";
+        return Stub::render('DTO/dto', [
+            'namespace'             => $ns,
+            'class'                 => $className,
+            'properties'            => empty($properties) ? '' : implode("\n", $properties) . "\n",
+            'constructor_signature' => implode(",\n", $constructorSignature),
+            'constructor_body'      => implode("\n", $constructorBody),
+            'from_request_body'     => implode("\n", $fromRequestBody),
+            'to_array_body'         => implode("\n", $toArrayBody),
+        ]);
     }
 
     private static function writeFile(string $path, string $content, bool $force): bool

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
@@ -113,13 +114,20 @@ class FormRequestGenerator
         }
         $rulesStr = implode("\n", $rulesExport);
 
-        $uses = "use Illuminate\\Foundation\\Http\\FormRequest;";
-        $uniquePatch = '';
+        $uses = [
+            'use Illuminate\\Foundation\\Http\\FormRequest;',
+        ];
+
+        $rulesBody = '';
 
         if ($isUpdate) {
-            $uses .= "\nuse Illuminate\\Validation\\Rule;";
+            $uses[] = 'use Illuminate\\Validation\\Rule;';
             $routeParamVar = $routeParam ? ("'" . $routeParam . "'") : "'id'";
             $tableVal      = $table ? ("'" . $table . "'") : "'items'";
+
+            $rulesInit = $rulesStr === ''
+                ? '        $rules = [];'
+                : "        \$rules = [\n{$rulesStr}\n        ];";
 
             $uniquePatch = <<<PHP
 
@@ -154,52 +162,36 @@ class FormRequestGenerator
         }
         unset(\$pipe);
 PHP;
+
+            $bodyParts = [
+                $rulesInit,
+                $uniquePatch,
+                '',
+                '        foreach ($rules as $k => &$arr) {',
+                '            if (is_array($arr)) {',
+                '                $arr = array_map(function ($x) { return $x; }, $arr);',
+                '            }',
+                '        }',
+                '        unset($arr);',
+                '',
+                '        return $rules;',
+            ];
+
+            $rulesBody = implode("\n", $bodyParts);
+        } else {
+            $rulesBody = $rulesStr === ''
+                ? '        return [];'
+                : "        return [\n{$rulesStr}\n        ];";
         }
-
-        $rulesBody = $isUpdate
-            ? <<<PHP
-
-        \$rules = [
-{$rulesStr}
-        ];{$uniquePatch}
-
-        foreach (\$rules as \$k => &\$arr) {
-            if (is_array(\$arr)) {
-                \$arr = array_map(function (\$x) { return \$x; }, \$arr);
-            }
-        }
-        unset(\$arr);
-
-        return \$rules;
-PHP
-            : <<<PHP
-
-        return [
-{$rulesStr}
-        ];
-PHP;
 
         $ns = $baseNamespace . '\\Http\\Requests';
 
-        return <<<PHP
-<?php
-
-namespace {$ns};
-
-{$uses}
-
-class {$className} extends FormRequest
-{
-    public function authorize(): bool
-    {
-        return true;
-    }
-
-    public function rules(): array
-    {{$rulesBody}
-}
-}
-PHP;
+        return Stub::render('FormRequest/request', [
+            'namespace'  => $ns,
+            'uses'       => implode("\n", $uses),
+            'class'      => $className,
+            'rules_body' => $rulesBody,
+        ]);
     }
 
     private static function writeFile(string $path, string $contents, bool $force): bool

--- a/src/Generators/ProviderGenerator.php
+++ b/src/Generators/ProviderGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 
 class ProviderGenerator
@@ -22,26 +23,14 @@ class ProviderGenerator
         $provNs    = str_replace('/', '\\', $provNs);
         $class     = "{$name}ServiceProvider";
 
-        $content = "<?php
-
-namespace {$provNs};
-
-use Illuminate\\Support\\ServiceProvider;
-
-class {$class} extends ServiceProvider
-{
-    public function register(): void
-    {
-        \$this->app->bind(\\{$repoIf}::class, \\{$repoNs}::class);
-        \$this->app->bind(\\{$serviceIf}::class, \\{$serviceNs}::class);
-    }
-
-    public function boot(): void
-    {
-        //
-    }
-}
-";
+        $content = Stub::render('Provider/provider', [
+            'namespace'           => $provNs,
+            'class'               => $class,
+            'repository_interface'=> $repoIf,
+            'repository_concrete' => $repoNs,
+            'service_interface'   => $serviceIf,
+            'service_concrete'    => $serviceNs,
+        ]);
         $providerFile = $providerPath . "/{$class}.php";
         $results = [
             $providerFile => self::writeFile($providerFile, $content, $force),

--- a/src/Generators/ResourceGenerator.php
+++ b/src/Generators/ResourceGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
@@ -63,7 +64,6 @@ class ResourceGenerator
             'Illuminate\\Http\\Resources\\Json\\JsonResource',
             $helperFqcn,
         ];
-        $usesBlock = 'use ' . implode(";\nuse ", array_unique($uses)) . ';';
 
         $body = [];
         foreach ($fillable as $field) {
@@ -85,24 +85,12 @@ class ResourceGenerator
                 : \$this->whenLoaded('{$rel}'),";
         }
 
-        $bodyBlock = implode("\n", $body);
-
-        return "<?php
-
-namespace {$ns};
-
-{$usesBlock}
-
-class {$className} extends JsonResource
-{
-    public function toArray(\$request): array
-    {
-        return [
-{$bodyBlock}
-        ];
-    }
-}
-";
+        return Stub::render('Resource/resource', [
+            'namespace' => $ns,
+            'uses'      => 'use ' . implode(";\nuse ", array_unique($uses)) . ';',
+            'class'     => $className,
+            'body'      => implode("\n", $body),
+        ]);
     }
 
     private static function writeFile(string $path, string $contents, bool $force): bool

--- a/src/Generators/ServiceGenerator.php
+++ b/src/Generators/ServiceGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 
 class ServiceGenerator
@@ -41,38 +42,28 @@ class ServiceGenerator
         if ($usesDto) {
             $interfaceUses[] = $dtoFqcn;
         }
-        $interfaceUsesBlock = 'use ' . implode(";\nuse ", $interfaceUses) . ';';
 
         $storeSignature  = $usesDto ? "public function store({$name}DTO \\$dto): Model;" : 'public function store(array \\$data): Model;';
         $updateSignature = $usesDto ? "public function update(int \\$id, {$name}DTO \\$dto): bool;" : 'public function update(int \\$id, array \\$data): bool;';
 
-        $interfaceTemplate = <<<PHP
-<?php
+        $interfaceContent = Stub::render('Service/interface', [
+            'namespace'        => $baseNamespace . '\\Services\\Contracts',
+            'uses'             => self::buildUses($interfaceUses),
+            'interface'        => $name . 'ServiceInterface',
+            'store_signature'  => $storeSignature,
+            'update_signature' => $updateSignature,
+        ]);
 
-namespace {$baseNamespace}\\Services\\Contracts;
-
-{$interfaceUsesBlock}
-
-interface {$name}ServiceInterface
-{
-    public function index();
-    public function show(int \\$id): ?Model;
-    {$storeSignature}
-    {$updateSignature}
-    public function destroy(int \\$id): bool;
-}
-PHP;
-
-        $results[$serviceInterfacePath] = self::writeFile($serviceInterfacePath, $interfaceTemplate, $force);
+        $results[$serviceInterfacePath] = self::writeFile($serviceInterfacePath, $interfaceContent, $force);
 
         // Service generation
         $serviceUses = [
-            "{$baseNamespace}\\Services\\Contracts\\{$name}ServiceInterface",
-            "{$baseNamespace}\\Services\\BaseService",
+            $baseNamespace . '\\Services\\Contracts\\' . $name . 'ServiceInterface',
+            $baseNamespace . '\\Services\\BaseService',
             'Illuminate\\Database\\Eloquent\\Model',
         ];
 
-        $repositoryType = $useInterfaces ? "{$name}RepositoryInterface" : "{$name}Repository";
+        $repositoryType = $useInterfaces ? $name . 'RepositoryInterface' : $name . 'Repository';
         $repositoryUse  = $useInterfaces ? $repoInterfaceFqcn : $repoConcreteFqcn;
         $serviceUses[]  = $repositoryUse;
 
@@ -82,8 +73,6 @@ PHP;
         if ($usesDto) {
             $serviceUses[] = $dtoFqcn;
         }
-        $serviceUses = array_unique($serviceUses);
-        $serviceUsesBlock = 'use ' . implode(";\nuse ", $serviceUses) . ';';
 
         $storeArgument  = $usesDto ? "{$name}DTO \\$dto" : 'array \\$data';
         $updateArgument = $usesDto ? "{$name}DTO \\$dto" : 'array \\$data';
@@ -94,50 +83,28 @@ PHP;
             ? '        return $this->repository->update($id, $dto->toArray());'
             : '        return $this->repository->update($id, $data);';
 
-        $serviceTemplate = <<<PHP
-<?php
+        $serviceContent = Stub::render('Service/concrete', [
+            'namespace'        => $baseNamespace . '\\Services',
+            'uses'             => self::buildUses($serviceUses),
+            'class'            => $name . 'Service',
+            'interface'        => $name . 'ServiceInterface',
+            'repository_type'  => $repositoryType,
+            'store_argument'   => $storeArgument,
+            'update_argument'  => $updateArgument,
+            'store_body'       => $storeBody,
+            'update_body'      => $updateBody,
+        ]);
 
-namespace {$baseNamespace}\\Services;
-
-{$serviceUsesBlock}
-
-class {$name}Service extends BaseService implements {$name}ServiceInterface
-{
-    public function __construct(public {$repositoryType} \\$repository)
-    {
-        parent::__construct(\$this->repository);
-    }
-
-    public function index()
-    {
-        return \$this->repository->getAll();
-    }
-
-    public function show(int \\$id): ?Model
-    {
-        return \$this->repository->find(\$id);
-    }
-
-    public function store({$storeArgument}): Model
-    {
-{$storeBody}
-    }
-
-    public function update(int \\$id, {$updateArgument}): bool
-    {
-{$updateBody}
-    }
-
-    public function destroy(int \\$id): bool
-    {
-        return \$this->repository->delete(\$id);
-    }
-}
-PHP;
-
-        $results[$serviceConcretePath] = self::writeFile($serviceConcretePath, $serviceTemplate, $force);
+        $results[$serviceConcretePath] = self::writeFile($serviceConcretePath, $serviceContent, $force);
 
         return $results;
+    }
+
+    private static function buildUses(array $uses): string
+    {
+        $uses = array_values(array_unique($uses));
+
+        return 'use ' . implode(";\nuse ", $uses) . ';';
     }
 
     private static function writeFile(string $path, string $contents, bool $force): bool

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
@@ -17,224 +18,36 @@ class TestGenerator
 
         $modelFqcn = $baseNamespace . '\\Models\\' . $name;
 
-        // NS کنترلر را مثل ControllerGenerator از مسیر کانفیگ می‌سازیم
         $paths          = config('module-generator.paths', []);
         $controllerRel  = $paths['controller'] ?? ($paths['controllers'] ?? 'Http/Controllers/Api/V1');
         $controllerNs   = self::controllerNamespaceFromRel($baseNamespace, $controllerRel, $controllerSubfolder);
         $controllerFqcn = $controllerNs . '\\' . $name . 'Controller';
 
-        $resourceSegment   = Str::kebab(Str::pluralStudly($name)); // products
-        $testRouteSegment  = 'test-' . $resourceSegment;
-        $baseUri           = '/' . $testRouteSegment;
+        $resourceSegment  = Str::kebab(Str::pluralStudly($name));
+        $testRouteSegment = 'test-' . $resourceSegment;
+        $baseUri          = '/' . $testRouteSegment;
 
         $fillable       = self::getFillable($modelFqcn);
         $fillableExport = self::exportArray($fillable);
 
-        // baseNamespace را به‌صورت literal امن داخل کد تست قرار می‌دهیم
         $baseNsLiteral = var_export($baseNamespace, true);
 
-        $content = <<<PHP
-<?php
-
-namespace Tests\\Feature;
-
-use Tests\\TestCase;
-use Illuminate\\Foundation\\Testing\\RefreshDatabase;
-use Illuminate\\Foundation\\Testing\\WithFaker;
-use Illuminate\\Support\\Facades\\Route;
-
-class {$className} extends TestCase
-{
-    use RefreshDatabase, WithFaker;
-
-    protected string \$baseUri = '{$baseUri}';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // روت‌های آزمایشی مستقل از روت‌های پروژه
-        Route::middleware('api')->group(function () {
-            Route::apiResource('{$testRouteSegment}', \\{$controllerFqcn}::class);
-        });
-    }
-
-    /**
-     * فیلدهای fillable مدل
-     */
-    private function fillable(): array
-    {
-        return {$fillableExport};
-    }
-
-    /**
-     * ساخت payload معتبر/نسبتاً معتبر برای store/update
-     * خروجی: [payload, canCreate]
-     */
-    private function buildValidPayload(bool \$forCreate = true): array
-    {
-        \$payload = [];
-        \$canCreate = true;
-
-        foreach (\$this->fillable() as \$field) {
-            if (str_ends_with(\$field, '_at')) {
-                continue;
-            }
-            if (str_ends_with(\$field, '_id')) {
-                \$base = substr(\$field, 0, -3);
-                \$related = {$baseNsLiteral} . '\\\\Models\\\\' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', \$base)));
-
-                \$id = null;
-                if (class_exists(\$related)) {
-                    if (method_exists(\$related, 'factory')) {
-                        \$id = \$related::factory()->create()->getKey();
-                    } else {
-                        try {
-                            \$obj = new \$related();
-                            \$fill = method_exists(\$obj, 'getFillable') ? \$obj->getFillable() : [];
-                            \$data = [];
-                            foreach (\$fill as \$f) {
-                                if (str_ends_with(\$f, '_id')) { continue; }
-                                if (stripos(\$f, 'email') !== false) { \$data[\$f] = 'x'.uniqid().'@example.test'; continue; }
-                                if (stripos(\$f, 'slug')  !== false) { \$data[\$f] = 'slug-'.uniqid(); continue; }
-                                if (stripos(\$f, 'name')  !== false) { \$data[\$f] = 'Name '.uniqid(); continue; }
-                                if (stripos(\$f, 'price') !== false || stripos(\$f, 'amount') !== false) { \$data[\$f] = 1; continue; }
-                                if (stripos(\$f, 'is_') === 0 || stripos(\$f, 'has_') === 0) { \$data[\$f] = true; continue; }
-                                \$data[\$f] = 'val';
-                            }
-                            \$obj = \$related::query()->create(\$data);
-                            \$id = \$obj->getKey();
-                        } catch (\\Throwable \$e) {}
-                    }
-                }
-                if (\$id === null) {
-                    \$canCreate = false;
-                } else {
-                    \$payload[\$field] = \$id;
-                }
-                continue;
-            }
-
-            if (stripos(\$field, 'email') !== false) {
-                \$payload[\$field] = 'u'.uniqid().'@example.test';
-            } elseif (stripos(\$field, 'slug') !== false || stripos(\$field, 'code') !== false) {
-                \$payload[\$field] = 'slug-'.uniqid();
-            } elseif (stripos(\$field, 'name') !== false || stripos(\$field, 'title') !== false) {
-                \$payload[\$field] = 'Title '.uniqid();
-            } elseif (stripos(\$field, 'price') !== false || stripos(\$field, 'amount') !== false || stripos(\$field, 'rate') !== false) {
-                \$payload[\$field] = 1000;
-            } elseif (stripos(\$field, 'is_') === 0 || stripos(\$field, 'has_') === 0) {
-                \$payload[\$field] = true;
-            } else {
-                \$payload[\$field] = 'text';
-            }
-        }
-
-        return [\$payload, \$canCreate];
-    }
-
-    private function createModel(): \\{$modelFqcn}
-    {
-        if (method_exists(\\{$modelFqcn}::class, 'factory')) {
-            return \\{$modelFqcn}::factory()->create();
-        }
-        [\$payload, \$can] = \$this->buildValidPayload(true);
-        return \\{$modelFqcn}::query()->create(\$payload);
-    }
-
-    public function test_index_returns_list(): void
-    {
-        try {
-            if (method_exists(\\{$modelFqcn}::class, 'factory')) {
-                \\{$modelFqcn}::factory()->count(3)->create();
-            }
-        } catch (\\Throwable \$e) {}
-        \$res = \$this->json('GET', \$this->baseUri);
-        \$res->assertStatus(200)->assertJsonStructure(['success', 'message', 'data']);
-    }
-
-    public function test_store_creates_resource_with_valid_data_or_422_when_unresolvable_fk(): void
-    {
-        [\$payload, \$canCreate] = \$this->buildValidPayload(true);
-        \$res = \$this->postJson(\$this->baseUri, \$payload);
-        if (\$canCreate) {
-            \$res->assertStatus(201)->assertJson(['success' => true]);
-        } else {
-            \$res->assertStatus(422);
-        }
-    }
-
-    public function test_store_returns_validation_error_for_duplicate_unique_when_applicable(): void
-    {
-        if (!in_array('slug', \$this->fillable(), true)) {
-            \$this->markTestSkipped('no unique-like field (slug) to test duplication');
-        }
-        \$existing = \$this->createModel();
-        [\$payload, \$can] = \$this->buildValidPayload(true);
-        \$payload['slug'] = \$existing->slug;
-        \$res = \$this->postJson(\$this->baseUri, \$payload);
-        \$res->assertStatus(422);
-    }
-
-    public function test_show_returns_single_resource(): void
-    {
-        \$model = \$this->createModel();
-        \$res = \$this->getJson(\$this->baseUri . '/' . \$model->getKey());
-        \$res->assertStatus(200)->assertJson(['success' => true]);
-    }
-
-    public function test_show_returns_404_for_missing_resource(): void
-    {
-        \$res = \$this->getJson(\$this->baseUri . '/999999999');
-        \$res->assertStatus(404);
-    }
-
-    public function test_update_updates_resource_with_valid_data(): void
-    {
-        \$model = \$this->createModel();
-        [\$payload, \$can] = \$this->buildValidPayload(false);
-        foreach (\$payload as \$k => \$v) {
-            if (is_string(\$v) && !str_ends_with(\$k, '_id')) {
-                \$payload[\$k] = 'updated-' . uniqid();
-                break;
-            }
-        }
-        \$res = \$this->patchJson(\$this->baseUri . '/' . \$model->getKey(), \$payload);
-        (\$payload ? \$res->assertStatus(200) : \$res->assertStatus(422));
-    }
-
-    public function test_update_returns_validation_error_on_duplicate_unique_when_applicable(): void
-    {
-        if (!in_array('slug', \$this->fillable(), true)) {
-            \$this->markTestSkipped('no unique-like field (slug) to test duplication on update');
-        }
-        \$a = \$this->createModel();
-        \$b = \$this->createModel();
-        \$res = \$this->patchJson(\$this->baseUri . '/' . \$b->getKey(), ['slug' => \$a->slug]);
-        \$res->assertStatus(422);
-    }
-
-    public function test_destroy_deletes_resource(): void
-    {
-        \$model = \$this->createModel();
-        \$res = \$this->deleteJson(\$this->baseUri . '/' . \$model->getKey());
-        \$res->assertStatus(204);
-    }
-
-    public function test_destroy_returns_404_for_missing_resource(): void
-    {
-        \$res = \$this->deleteJson(\$this->baseUri . '/999999999');
-        \$res->assertStatus(404);
-    }
-}
-PHP;
+        $content = Stub::render('Test/feature', [
+            'class'                  => $className,
+            'base_uri'               => $baseUri,
+            'test_route_segment'     => $testRouteSegment,
+            'controller_fqcn'        => $controllerFqcn,
+            'fillable_export'        => $fillableExport,
+            'base_namespace_literal' => $baseNsLiteral,
+            'model_fqcn'             => $modelFqcn,
+        ]);
 
         return [$filePath => self::writeFile($filePath, $content, $force)];
     }
 
     private static function controllerNamespaceFromRel(string $baseNamespace, string $controllerRel, ?string $subfolder): string
     {
-        $rel = str_replace('/', '\\', trim($controllerRel, '/\\')); // e.g. Http/Controllers/Api/V1
+        $rel = str_replace('/', '\\', trim($controllerRel, '/\\'));
         $ns  = $baseNamespace . '\\' . $rel;
         if ($subfolder) {
             $ns .= '\\' . str_replace(['/', '\\'], '\\', trim($subfolder, '/\\'));

--- a/src/ModuleGeneratorServiceProvider.php
+++ b/src/ModuleGeneratorServiceProvider.php
@@ -39,5 +39,13 @@ class ModuleGeneratorServiceProvider extends ServiceProvider
             __DIR__ . '/config/module-generator.php'        => config_path('module-generator.php'),
             __DIR__ . '/Stubs/Helpers/StatusHelper.php'     => app_path('Helpers/StatusHelper.php'),
         ], 'module-generator');
+
+        $resourceStubPath = function_exists('resource_path')
+            ? resource_path('stubs/module-generator')
+            : app()->resourcePath('stubs/module-generator');
+
+        $this->publishes([
+            __DIR__ . '/Stubs/Module' => $resourceStubPath,
+        ], 'module-generator-stubs');
     }
 }

--- a/src/Stubs/Module/Controller/api.stub
+++ b/src/Stubs/Module/Controller/api.stub
@@ -1,0 +1,48 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+class {{ class }}
+{
+    public function __construct(public {{ service_class }} $service) {}
+
+    public function index()
+    {
+{{ index_body }}
+    }
+
+    public function store({{ store_request_type }} $request)
+    {
+{{ store_payload }}
+        $model = $this->service->store({{ store_argument }});
+{{ store_response }}
+    }
+
+    public function show({{ model_class }} ${{ model_variable }}): mixed
+    {
+{{ relations_load }}
+{{ show_response }}
+    }
+
+    public function update({{ update_request_type }} $request, {{ model_class }} ${{ model_variable }})
+    {
+{{ update_payload }}
+        $updated = $this->service->update(${{ model_variable }}->id, {{ update_argument }});
+        if (!$updated) {
+            return StatusHelper::errorResponse('update failed', 422);
+        }
+        ${{ model_variable }}->refresh();
+{{ relations_load }}
+{{ update_response }}
+    }
+
+    public function destroy({{ model_class }} ${{ model_variable }})
+    {
+        $deleted = $this->service->destroy(${{ model_variable }}->id);
+        return $deleted
+            ? StatusHelper::successResponse(null, 'deleted', 204)
+            : StatusHelper::errorResponse('delete failed', 422);
+    }
+}

--- a/src/Stubs/Module/Controller/web.stub
+++ b/src/Stubs/Module/Controller/web.stub
@@ -1,0 +1,60 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+class {{ class }} extends Controller
+{
+    public function __construct(public {{ service_class }} $service) {}
+
+    public function index(): View
+    {
+        $items = $this->service->index();
+        return view('{{ view_base }}.index', compact('items'));
+    }
+
+    public function create(): View
+    {
+        return view('{{ view_base }}.create');
+    }
+
+    public function store({{ store_request_type }} $request): RedirectResponse
+    {
+        // @todo update validation rules and authorisation as needed.
+{{ store_payload }}
+        $this->service->store({{ store_argument }});
+
+        return redirect()->route('{{ route_name }}.index')
+            ->with('status', '{{ name }} created.');
+    }
+
+    public function show({{ model_class }} ${{ model_variable }}): View
+    {
+{{ relations_load }}
+        return view('{{ view_base }}.show', compact('{{ model_variable }}'));
+    }
+
+    public function edit({{ model_class }} ${{ model_variable }}): View
+    {
+{{ relations_load }}
+        return view('{{ view_base }}.edit', compact('{{ model_variable }}'));
+    }
+
+    public function update({{ update_request_type }} $request, {{ model_class }} ${{ model_variable }}): RedirectResponse
+    {
+{{ update_payload }}
+        $this->service->update(${{ model_variable }}->id, {{ update_argument }});
+
+        return redirect()->route('{{ route_name }}.show', ${{ model_variable }})
+            ->with('status', '{{ name }} updated.');
+    }
+
+    public function destroy({{ model_class }} ${{ model_variable }}): RedirectResponse
+    {
+        $this->service->destroy(${{ model_variable }}->id);
+
+        return redirect()->route('{{ route_name }}.index')
+            ->with('status', '{{ name }} deleted.');
+    }
+}

--- a/src/Stubs/Module/DTO/dto.stub
+++ b/src/Stubs/Module/DTO/dto.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+
+class {{ class }}
+{
+{{ properties }}
+    public function __construct(
+{{ constructor_signature }}
+    ) {
+{{ constructor_body }}
+    }
+
+    public static function fromRequest(Request $request): self
+    {
+        $dto = new self();
+{{ from_request_body }}
+        return $dto;
+    }
+
+    public function toArray(): array
+    {
+        $out = [];
+{{ to_array_body }}
+        return $out;
+    }
+}

--- a/src/Stubs/Module/FormRequest/request.stub
+++ b/src/Stubs/Module/FormRequest/request.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+class {{ class }} extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+{{ rules_body }}
+    }
+}

--- a/src/Stubs/Module/Provider/provider.stub
+++ b/src/Stubs/Module/Provider/provider.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\ServiceProvider;
+
+class {{ class }} extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(\{{ repository_interface }}::class, \{{ repository_concrete }}::class);
+        $this->app->bind(\{{ service_interface }}::class, \{{ service_concrete }}::class);
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/src/Stubs/Module/Repository/concrete.stub
+++ b/src/Stubs/Module/Repository/concrete.stub
@@ -1,0 +1,43 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ interface_fqcn }};
+use {{ base_repository_fqcn }};
+use {{ model_fqcn }};
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends BaseRepository implements {{ interface }}
+{
+    public function __construct(public {{ model }} $model)
+    {
+        parent::__construct($this->model);
+    }
+
+    public function getAll()
+    {
+        return $this->model->query()->latest()->get();
+    }
+
+    public function find(int $id): ?Model
+    {
+        return $this->model->find($id);
+    }
+
+    public function store(array $data): Model
+    {
+        return $this->model->create($data);
+    }
+
+    public function update(int $id, array $data): bool
+    {
+        $item = $this->find($id);
+        return $item ? $item->update($data) : false;
+    }
+
+    public function delete(int $id): bool
+    {
+        $item = $this->find($id);
+        return $item ? (bool) $item->delete() : false;
+    }
+}

--- a/src/Stubs/Module/Repository/contract.stub
+++ b/src/Stubs/Module/Repository/contract.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Model;
+
+interface {{ interface }}
+{
+    public function getAll();
+    public function find(int $id): ?Model;
+    public function store(array $data): Model;
+    public function update(int $id, array $data): bool;
+    public function delete(int $id): bool;
+}

--- a/src/Stubs/Module/Resource/resource.stub
+++ b/src/Stubs/Module/Resource/resource.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+class {{ class }} extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+{{ body }}
+        ];
+    }
+}

--- a/src/Stubs/Module/Service/concrete.stub
+++ b/src/Stubs/Module/Service/concrete.stub
@@ -1,0 +1,38 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+class {{ class }} extends BaseService implements {{ interface }}
+{
+    public function __construct(public {{ repository_type }} $repository)
+    {
+        parent::__construct($this->repository);
+    }
+
+    public function index()
+    {
+        return $this->repository->getAll();
+    }
+
+    public function show(int $id): ?Model
+    {
+        return $this->repository->find($id);
+    }
+
+    public function store({{ store_argument }}): Model
+    {
+{{ store_body }}
+    }
+
+    public function update(int $id, {{ update_argument }}): bool
+    {
+{{ update_body }}
+    }
+
+    public function destroy(int $id): bool
+    {
+        return $this->repository->delete($id);
+    }
+}

--- a/src/Stubs/Module/Service/interface.stub
+++ b/src/Stubs/Module/Service/interface.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ uses }}
+
+interface {{ interface }}
+{
+    public function index();
+    public function show(int $id): ?Model;
+    {{ store_signature }}
+    {{ update_signature }}
+    public function destroy(int $id): bool;
+}

--- a/src/Stubs/Module/Test/feature.stub
+++ b/src/Stubs/Module/Test/feature.stub
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Route;
+
+class {{ class }} extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected string $baseUri = '{{ base_uri }}';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // روت‌های آزمایشی مستقل از روت‌های پروژه
+        Route::middleware('api')->group(function () {
+            Route::apiResource('{{ test_route_segment }}', \{{ controller_fqcn }}::class);
+        });
+    }
+
+    /**
+     * فیلدهای fillable مدل
+     */
+    private function fillable(): array
+    {
+        return {{ fillable_export }};
+    }
+
+    /**
+     * ساخت payload معتبر/نسبتاً معتبر برای store/update
+     * خروجی: [payload, canCreate]
+     */
+    private function buildValidPayload(bool $forCreate = true): array
+    {
+        $payload = [];
+        $canCreate = true;
+
+        foreach ($this->fillable() as $field) {
+            if (str_ends_with($field, '_at')) {
+                continue;
+            }
+            if (str_ends_with($field, '_id')) {
+                $base = substr($field, 0, -3);
+                $related = {{ base_namespace_literal }} . '\\Models\\' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $base)));
+
+                $id = null;
+                if (class_exists($related)) {
+                    if (method_exists($related, 'factory')) {
+                        $id = $related::factory()->create()->getKey();
+                    } else {
+                        try {
+                            $obj = new $related();
+                            $fill = method_exists($obj, 'getFillable') ? $obj->getFillable() : [];
+                            $data = [];
+                            foreach ($fill as $f) {
+                                if (str_ends_with($f, '_id')) { continue; }
+                                if (stripos($f, 'email') !== false) { $data[$f] = 'x'.uniqid().'@example.test'; continue; }
+                                if (stripos($f, 'slug')  !== false) { $data[$f] = 'slug-'.uniqid(); continue; }
+                                if (stripos($f, 'name')  !== false) { $data[$f] = 'Name '.uniqid(); continue; }
+                                if (stripos($f, 'price') !== false || stripos($f, 'amount') !== false) { $data[$f] = 1; continue; }
+                                if (stripos($f, 'is_') === 0 || stripos($f, 'has_') === 0) { $data[$f] = true; continue; }
+                                $data[$f] = 'val';
+                            }
+                            $obj = $related::query()->create($data);
+                            $id = $obj->getKey();
+                        } catch (\Throwable $e) {}
+                    }
+                }
+                if ($id === null) {
+                    $canCreate = false;
+                } else {
+                    $payload[$field] = $id;
+                }
+                continue;
+            }
+
+            if (stripos($field, 'email') !== false) {
+                $payload[$field] = 'u'.uniqid().'@example.test';
+            } elseif (stripos($field, 'slug') !== false || stripos($field, 'code') !== false) {
+                $payload[$field] = 'slug-'.uniqid();
+            } elseif (stripos($field, 'name') !== false || stripos($field, 'title') !== false) {
+                $payload[$field] = 'Title '.uniqid();
+            } elseif (stripos($field, 'price') !== false || stripos($field, 'amount') !== false || stripos($field, 'rate') !== false) {
+                $payload[$field] = 1000;
+            } elseif (stripos($field, 'is_') === 0 || stripos($field, 'has_') === 0) {
+                $payload[$field] = true;
+            } else {
+                $payload[$field] = 'text';
+            }
+        }
+
+        return [$payload, $canCreate];
+    }
+
+    private function createModel(): \{{ model_fqcn }}
+    {
+        if (method_exists(\{{ model_fqcn }}::class, 'factory')) {
+            return \{{ model_fqcn }}::factory()->create();
+        }
+        [$payload, $can] = $this->buildValidPayload(true);
+        return \{{ model_fqcn }}::query()->create($payload);
+    }
+
+    public function test_index_returns_list(): void
+    {
+        try {
+            if (method_exists(\{{ model_fqcn }}::class, 'factory')) {
+                \{{ model_fqcn }}::factory()->count(3)->create();
+            }
+        } catch (\Throwable $e) {}
+        $res = $this->json('GET', $this->baseUri);
+        $res->assertStatus(200)->assertJsonStructure(['success', 'message', 'data']);
+    }
+
+    public function test_store_creates_resource_with_valid_data_or_422_when_unresolvable_fk(): void
+    {
+        [$payload, $canCreate] = $this->buildValidPayload(true);
+        $res = $this->postJson($this->baseUri, $payload);
+        if ($canCreate) {
+            $res->assertStatus(201)->assertJson(['success' => true]);
+        } else {
+            $res->assertStatus(422);
+        }
+    }
+
+    public function test_store_returns_validation_error_for_duplicate_unique_when_applicable(): void
+    {
+        if (!in_array('slug', $this->fillable(), true)) {
+            $this->markTestSkipped('no unique-like field (slug) to test duplication');
+        }
+        $existing = $this->createModel();
+        [$payload, $can] = $this->buildValidPayload(true);
+        $payload['slug'] = $existing->slug;
+        $res = $this->postJson($this->baseUri, $payload);
+        $res->assertStatus(422);
+    }
+
+    public function test_show_returns_single_resource(): void
+    {
+        $model = $this->createModel();
+        $res = $this->getJson($this->baseUri . '/' . $model->getKey());
+        $res->assertStatus(200)->assertJson(['success' => true]);
+    }
+
+    public function test_show_returns_404_for_missing_resource(): void
+    {
+        $res = $this->getJson($this->baseUri . '/999999999');
+        $res->assertStatus(404);
+    }
+
+    public function test_update_updates_resource_with_valid_data(): void
+    {
+        $model = $this->createModel();
+        [$payload, $can] = $this->buildValidPayload(false);
+        foreach ($payload as $k => $v) {
+            if (is_string($v) && !str_ends_with($k, '_id')) {
+                $payload[$k] = 'updated-' . uniqid();
+                break;
+            }
+        }
+        $res = $this->patchJson($this->baseUri . '/' . $model->getKey(), $payload);
+        ($payload ? $res->assertStatus(200) : $res->assertStatus(422));
+    }
+
+    public function test_update_returns_validation_error_on_duplicate_unique_when_applicable(): void
+    {
+        if (!in_array('slug', $this->fillable(), true)) {
+            $this->markTestSkipped('no unique-like field (slug) to test duplication on update');
+        }
+        $a = $this->createModel();
+        $b = $this->createModel();
+        $res = $this->patchJson($this->baseUri . '/' . $b->getKey(), ['slug' => $a->slug]);
+        $res->assertStatus(422);
+    }
+
+    public function test_destroy_deletes_resource(): void
+    {
+        $model = $this->createModel();
+        $res = $this->deleteJson($this->baseUri . '/' . $model->getKey());
+        $res->assertStatus(204);
+    }
+
+    public function test_destroy_returns_404_for_missing_resource(): void
+    {
+        $res = $this->deleteJson($this->baseUri . '/999999999');
+        $res->assertStatus(404);
+    }
+}

--- a/src/Support/Stub.php
+++ b/src/Support/Stub.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Efati\ModuleGenerator\Support;
+
+use Illuminate\Support\Facades\File;
+
+class Stub
+{
+    public static function render(string $stub, array $replacements = []): string
+    {
+        $path = self::resolvePath($stub);
+
+        $contents = File::get($path);
+
+        foreach ($replacements as $key => $value) {
+            $contents = str_replace('{{ ' . $key . ' }}', $value, $contents);
+        }
+
+        return $contents;
+    }
+
+    public static function path(string $stub): string
+    {
+        return self::resolvePath($stub);
+    }
+
+    protected static function resolvePath(string $stub): string
+    {
+        $normalized = str_replace(['\\', '//'], '/', $stub);
+
+        $resourcePath = function_exists('resource_path')
+            ? resource_path('stubs/module-generator/' . $normalized . '.stub')
+            : app()->resourcePath('stubs/module-generator/' . $normalized . '.stub');
+
+        $published = $resourcePath;
+        if (File::exists($published)) {
+            return $published;
+        }
+
+        $package = __DIR__ . '/../Stubs/Module/' . $normalized . '.stub';
+        if (File::exists($package)) {
+            return $package;
+        }
+
+        throw new \RuntimeException("Stub file [{$stub}] not found.");
+    }
+}


### PR DESCRIPTION
## Summary
- move controller, repository, service, form request, resource, provider, DTO and test templates into dedicated stub files and load them through a new Stub helper
- update generators to prefer published stubs so teams can override the defaults and register a new `module-generator-stubs` publish tag
- document how to publish and customise the module stubs for team-specific standards

## Testing
- php -l src/Generators/DTOGenerator.php
- php -l src/Generators/ServiceGenerator.php
- php -l src/Generators/ControllerGenerator.php
- php -l src/Generators/ResourceGenerator.php
- php -l src/Generators/ProviderGenerator.php
- php -l src/Generators/TestGenerator.php
- php -l src/Generators/FormRequestGenerator.php
- php -l src/Generators/RepositoryGenerator.php
- php -l src/Support/Stub.php
- php -l src/ModuleGeneratorServiceProvider.php

------
https://chatgpt.com/codex/tasks/task_e_68cd4b7b98048321af76a9994d96a85c