### PR TITLE
Ensure resource generator outputs use statements

### DIFF
--- a/src/Generators/ResourceGenerator.php
+++ b/src/Generators/ResourceGenerator.php
@@ -145,6 +145,8 @@ class ResourceGenerator
             $helperFqcn,
         ];
 
+        $usesBlock = self::buildUses($uses);
+
         $body = [];
         foreach ($fillable as $field) {
             $castType = self::normalizeCast($casts[$field] ?? null);
@@ -167,8 +169,19 @@ class ResourceGenerator
 
         $bodyBlock = implode("\n", $body);
 
-        return "<?php\n\nnamespace {$ns};\n\n{$usesBlock}\n\nclass {$className} extends JsonResource\n{\n    public function toArray(\\$request): array\n    {\n        return [\n{$bodyBlock}\n        ];\n    }\n}\n";
+        return "<?php\n\nnamespace {$ns};\n\n{$usesBlock}\n\nclass {$className} extends JsonResource\n{\n    public function toArray(\$request): array\n    {\n        return [\n{$bodyBlock}\n        ];\n    }\n}\n";
 
+    }
+
+    private static function buildUses(array $uses): string
+    {
+        $uses = array_values(array_unique(array_filter($uses)));
+
+        if (empty($uses)) {
+            return '';
+        }
+
+        return 'use ' . implode(";\nuse ", $uses) . ';';
     }
 
     private static function writeFile(string $path, string $contents, bool $force): bool


### PR DESCRIPTION
## Summary
- format the resource generator import list into a block of `use` statements
- add a helper to normalise and de-duplicate imports before rendering

## Testing
- php -l src/Generators/ResourceGenerator.php
- php run_resource_generator.php
- php -l tmp_app/Http/Resources/SampleResource.php

------
https://chatgpt.com/codex/tasks/task_e_68cd687ddc048321983229e746cfa423