### PR TITLE
Fix SchemaParser import

### DIFF
--- a/src/Commands/MakeModuleCommand.php
+++ b/src/Commands/MakeModuleCommand.php
@@ -13,6 +13,7 @@ use Efati\ModuleGenerator\Generators\ControllerGenerator;
 use Efati\ModuleGenerator\Generators\FormRequestGenerator;
 use Efati\ModuleGenerator\Generators\ResourceGenerator;
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
+use Efati\ModuleGenerator\Support\SchemaParser;
 
 
 class MakeModuleCommand extends Command


### PR DESCRIPTION
## Summary
- add the missing SchemaParser import so the command resolves the parser helper

## Testing
- php artisan make:module Product --fields="name:string" *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c0bb1b48321a2689bb8907dac6d