### PR TITLE
Handle schema-less generator fallbacks

### DIFF
--- a/src/Generators/DTOGenerator.php
+++ b/src/Generators/DTOGenerator.php
@@ -43,16 +43,26 @@ class DTOGenerator
 
     {
         if (!class_exists($modelFqcn)) {
-            return SchemaParser::fieldNames($schema);
+            return [];
         }
+
         $model = new $modelFqcn();
-        $fillable = method_exists($model, 'getFillable') ? $model->getFillable() : [];
 
-        if (empty($fillable)) {
-            return SchemaParser::fieldNames($schema);
+        if (method_exists($model, 'getFillable')) {
+            $fillable = (array) $model->getFillable();
+            if (!empty($fillable)) {
+                return array_values($fillable);
+            }
         }
 
-        return $fillable;
+        if (property_exists($model, 'fillable') && is_array($model->fillable)) {
+            $fillable = array_filter($model->fillable, fn ($value) => is_string($value) && $value !== '');
+            if (!empty($fillable)) {
+                return array_values($fillable);
+            }
+        }
+
+        return [];
     }
 
     private static function build(string $className, string $baseNamespace, array $fillable): string

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -62,17 +62,22 @@ class FormRequestGenerator
     private static function buildRules(string $modelFqcn, string $table, ?array $fieldMeta = null): array
 
     {
-        if (is_array($fieldMeta) && !empty($fieldMeta)) {
-            return MigrationFieldParser::buildValidationRules($fieldMeta, $table);
+        $schema = [];
+        if (is_array($fieldMeta)) {
+            $schema = $fieldMeta;
+
+            if (!empty($schema)) {
+                return MigrationFieldParser::buildValidationRules($schema, $table);
+            }
         }
 
         $fillable = [];
         if (class_exists($modelFqcn)) {
             $m = new $modelFqcn();
-            $fillable = method_exists($m, 'getFillable') ? $m->getFillable() : [];
+            $fillable = method_exists($m, 'getFillable') ? (array) $m->getFillable() : [];
         }
 
-        if (empty($fillable)) {
+        if (empty($fillable) && !empty($schema)) {
             $fillable = SchemaParser::fieldNames($schema);
         }
 


### PR DESCRIPTION
## Summary
- return an empty array from `DTOGenerator::getFillable` when the model class or its fillable list is unavailable, including support for the fillable property as a fallback
- guard `FormRequestGenerator::buildRules` so schema data is always defined before invoking `SchemaParser`

## Testing
- php -l src/Generators/DTOGenerator.php
- php -l src/Generators/FormRequestGenerator.php
- php /tmp/manual_form_request.php

------
https://chatgpt.com/codex/tasks/task_e_68cd93f7a8f08321ab7b6afa30d12bcc