### PR TITLE
Fix DTO placeholder escaping in ServiceGenerator

### DIFF
--- a/src/Generators/ServiceGenerator.php
+++ b/src/Generators/ServiceGenerator.php
@@ -43,8 +43,8 @@ class ServiceGenerator
             $interfaceUses[] = $dtoFqcn;
         }
 
-        $storeSignature  = $usesDto ? "public function store({$name}DTO \\$dto): Model;" : 'public function store(array \\$data): Model;';
-        $updateSignature = $usesDto ? "public function update(int \\$id, {$name}DTO \\$dto): bool;" : 'public function update(int \\$id, array \\$data): bool;';
+        $storeSignature  = $usesDto ? "public function store({$name}DTO \$dto): Model;" : 'public function store(array $data): Model;';
+        $updateSignature = $usesDto ? "public function update(int \$id, {$name}DTO \$dto): bool;" : 'public function update(int $id, array $data): bool;';
 
         $interfaceContent = Stub::render('Service/interface', [
             'namespace'        => $baseNamespace . '\\Services\\Contracts',
@@ -74,8 +74,8 @@ class ServiceGenerator
             $serviceUses[] = $dtoFqcn;
         }
 
-        $storeArgument  = $usesDto ? "{$name}DTO \\$dto" : 'array \\$data';
-        $updateArgument = $usesDto ? "{$name}DTO \\$dto" : 'array \\$data';
+        $storeArgument  = $usesDto ? "{$name}DTO \$dto" : 'array $data';
+        $updateArgument = $usesDto ? "{$name}DTO \$dto" : 'array $data';
         $storeBody      = $usesDto
             ? '        return $this->repository->store($dto->toArray());'
             : '        return $this->repository->store($data);';


### PR DESCRIPTION
## Summary
- correctly escape DTO placeholders in the service interface signatures so generation no longer errors at runtime
- align the generated service method arguments for DTO and array modes to use literal `$data` identifiers

## Testing
- php -l src/Generators/ServiceGenerator.php

------
https://chatgpt.com/codex/tasks/task_e_68d10a26cf34832186c796b7a3d4492d