### PR TITLE
Fix FormRequest generator stub reference

### DIFF
--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -2,11 +2,11 @@
 
 namespace Efati\ModuleGenerator\Generators;
 
-use Efati\ModuleGenerator\Support\MigrationFieldParser;
-
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Efati\ModuleGenerator\Support\MigrationFieldParser;
 use Efati\ModuleGenerator\Support\SchemaParser;
+use Efati\ModuleGenerator\Support\Stub;
 
 class FormRequestGenerator
 {


### PR DESCRIPTION
## Summary
- import the module generator Stub support class inside FormRequestGenerator
- ensure FormRequestGenerator can render request stubs without missing class errors

## Testing
- not run (package does not provide a phpunit binary)


------
https://chatgpt.com/codex/tasks/task_e_68d10fa450f88321813cbc0ff6ff7b64