### PR TITLE
Fix feature test generator syntax and stub

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -3,10 +3,9 @@
 namespace Efati\ModuleGenerator\Generators;
 
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
-
+use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Efati\ModuleGenerator\Support\SchemaParser;
 
 class TestGenerator
 {
@@ -17,7 +16,6 @@ class TestGenerator
         bool $force = false,
         ?array $fields = null
     ): array {
-
         $testsPath = base_path(config('module-generator.tests.feature', 'tests/Feature'));
         File::ensureDirectoryExists($testsPath);
 
@@ -35,238 +33,23 @@ class TestGenerator
         $testRouteSegment = 'test-' . $resourceSegment;
         $baseUri          = '/' . $testRouteSegment;
 
-        $fieldMetadata   = self::resolveFieldMetadata($modelFqcn, $fields, $baseNamespace);
-        $fillable        = array_keys($fieldMetadata);
-        $fillableExport  = self::exportArray($fillable);
-        $metadataExport  = self::exportAssoc($fieldMetadata, 2);
-
+        $fieldMetadata  = self::resolveFieldMetadata($modelFqcn, $fields, $baseNamespace);
+        $fillable       = array_keys($fieldMetadata);
+        $fillableExport = self::exportArray($fillable);
+        $metadataExport = self::exportAssoc($fieldMetadata, 2);
 
         $content = Stub::render('Test/feature', [
-            'class'                  => $className,
-            'base_uri'               => $baseUri,
-            'test_route_segment'     => $testRouteSegment,
-            'controller_fqcn'        => $controllerFqcn,
-            'fillable_export'        => $fillableExport,
-            'base_namespace_literal' => $baseNsLiteral,
-            'model_fqcn'             => $modelFqcn,
+            'class'                 => $className,
+            'base_uri'              => $baseUri,
+            'test_route_segment'    => $testRouteSegment,
+            'controller_fqcn'       => $controllerFqcn,
+            'fillable_export'       => $fillableExport,
+            'field_metadata_export' => $metadataExport,
+            'model_fqcn'            => $modelFqcn,
         ]);
 
-        $content = <<<PHP
-<?php
-
-namespace Tests\\Feature;
-
-use Tests\\TestCase;
-use Illuminate\\Foundation\\Testing\\RefreshDatabase;
-use Illuminate\\Foundation\\Testing\\WithFaker;
-use Illuminate\\Support\\Facades\\Route;
-
-class {$className} extends TestCase
-{
-    use RefreshDatabase, WithFaker;
-
-    protected string \$baseUri = '{$baseUri}';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Route::middleware('api')->group(function () {
-            Route::apiResource('{$testRouteSegment}', \\{$controllerFqcn}::class);
-        });
+        return [$filePath => self::writeFile($filePath, $content, $force)];
     }
-
-    private function fillable(): array
-
-    {
-        $rel = str_replace('/', '\\', trim($controllerRel, '/\\'));
-        $ns  = $baseNamespace . '\\' . $rel;
-        if ($subfolder) {
-            $ns .= '\\' . str_replace(['/', '\\'], '\\', trim($subfolder, '/\\'));
-        }
-        return $ns;
-    }
-
-    private function fieldMetadata(): array
-    {
-        return {$metadataExport};
-    }
-
-    private function buildValidPayload(bool \$forCreate = true): array
-    {
-        \$payload = [];
-        \$canCreate = true;
-        \$metadata = \$this->fieldMetadata();
-
-        foreach (\$this->fillable() as \$field) {
-            \$meta = \$metadata[\$field] ?? [];
-
-            if (!empty(\$meta['foreign']['related_model'])) {
-                \$related = \$meta['foreign']['related_model'];
-                \$id = null;
-                if (is_string(\$related) && class_exists(\$related)) {
-                    if (method_exists(\$related, 'factory')) {
-                        \$id = \$related::factory()->create()->getKey();
-                    } else {
-                        try {
-                            \$obj = new \$related();
-                            \$fill = method_exists(\$obj, 'getFillable') ? \$obj->getFillable() : [];
-                            \$data = [];
-                            foreach (\$fill as \$f) {
-                                if (str_ends_with(\$f, '_id')) { continue; }
-                                if (stripos(\$f, 'email') !== false) { \$data[\$f] = 'x'.uniqid().'@example.test'; continue; }
-                                if (stripos(\$f, 'slug') !== false) { \$data[\$f] = 'slug-'.uniqid(); continue; }
-                                if (stripos(\$f, 'name') !== false) { \$data[\$f] = 'Name '.uniqid(); continue; }
-                                if (stripos(\$f, 'price') !== false || stripos(\$f, 'amount') !== false) { \$data[\$f] = 1; continue; }
-                                if (stripos(\$f, 'is_') === 0 || stripos(\$f, 'has_') === 0) { \$data[\$f] = true; continue; }
-                                \$data[\$f] = 'val';
-                            }
-                            \$obj = \$related::query()->create(\$data);
-                            \$id = \$obj->getKey();
-                        } catch (\Throwable \$e) {}
-                    }
-                }
-                if (\$id === null) {
-                    \$canCreate = false;
-                } else {
-                    \$payload[\$field] = \$id;
-                }
-                continue;
-            }
-
-            \$payload[\$field] = \$this->fakeValueForField(\$field, \$meta);
-
-        }
-        $m        = new $modelFqcn();
-        $fillable = method_exists($m, 'getFillable') ? $m->getFillable() : [];
-
-        return [\$payload, \$canCreate];
-    }
-
-    private function fakeValueForField(string \$field, array \$meta): mixed
-    {
-        if (!empty(\$meta['enum']) && is_array(\$meta['enum'])) {
-            return \$meta['enum'][0];
-        }
-
-        \$cast = \$meta['cast'] ?? null;
-        if (is_string(\$cast) && str_contains(\$cast, ':')) {
-            \$cast = strtolower(strtok(\$cast, ':'));
-        }
-        \$type = \$meta['type'] ?? null;
-
-        if (stripos(\$field, 'email') !== false) {
-            return 'u'.uniqid().'@example.test';
-        }
-        if (stripos(\$field, 'slug') !== false || stripos(\$field, 'code') !== false) {
-            return 'slug-'.uniqid();
-        }
-        if (stripos(\$field, 'name') !== false || stripos(\$field, 'title') !== false) {
-            return 'Title '.uniqid();
-        }
-        if (stripos(\$field, 'price') !== false || stripos(\$field, 'amount') !== false || stripos(\$field, 'rate') !== false) {
-            return 1000;
-        }
-        if (stripos(\$field, 'is_') === 0 || stripos(\$field, 'has_') === 0) {
-            return true;
-        }
-
-        if (in_array(\$type, ['boolean'], true) || in_array(\$cast, ['bool', 'boolean'], true)) {
-            return true;
-        }
-        if (in_array(\$type, ['integer'], true) || in_array(\$cast, ['int', 'integer'], true)) {
-            return 1;
-        }
-        if (in_array(\$type, ['float', 'decimal'], true) || in_array(\$cast, ['float', 'double', 'decimal'], true)) {
-            return 1.0;
-        }
-        if (in_array(\$type, ['json'], true) || in_array(\$cast, ['array', 'collection'], true)) {
-            return ['sample' => 'data'];
-        }
-        if (\$type === 'date') {
-            return '2024-01-01';
-        }
-        if (\$type === 'datetime') {
-            return '2024-01-01 00:00:00';
-        }
-        if (\$type === 'uuid') {
-            return 'uuid-'.uniqid();
-        }
-
-        return 'text';
-    }
-
-    private function createModel(): \\{$modelFqcn}
-    {
-        if (method_exists(\\{$modelFqcn}::class, 'factory')) {
-            return \\{$modelFqcn}::factory()->create();
-
-        }
-
-    public function test_index_returns_list(): void
-    {
-        try {
-            if (method_exists(\\{$modelFqcn}::class, 'factory')) {
-                \\{$modelFqcn}::factory()->count(3)->create();
-            }
-        } catch (\Throwable \$e) {}
-        \$res = \$this->json('GET', \$this->baseUri);
-        \$res->assertStatus(200)->assertJsonStructure(['success', 'message', 'data']);
-
-    }
-
-    private static function exportArray(array $arr): string
-    {
-        $items = array_map(fn($v) => var_export($v, true), $arr);
-        return '[' . implode(', ', $items) . ']';
-    }
-
-    private static function exportSchema(array $schema): string
-    {
-        if (empty($schema)) {
-            return '[]';
-        }
-
-        $assoc = [];
-        foreach ($schema as $field) {
-            if (!isset($field['name'])) {
-                continue;
-            }
-
-            $foreign = null;
-            if (!empty($field['foreign']) && is_array($field['foreign'])) {
-                $table  = $field['foreign']['table'] ?? null;
-                $column = $field['foreign']['column'] ?? 'id';
-                if ($table) {
-                    $foreign = ['table' => $table, 'column' => $column];
-                }
-            }
-
-            $assoc[$field['name']] = [
-                'type'     => SchemaParser::normalizeType((string) ($field['type'] ?? 'string')),
-                'nullable' => (bool) ($field['nullable'] ?? false),
-                'unique'   => (bool) ($field['unique'] ?? false),
-                'foreign'  => $foreign,
-            ];
-        }
-
-        if (empty($assoc)) {
-            return '[]';
-        }
-
-        return self::exportValue($assoc, 2);
-    }
-
-    private static function exportValue(mixed $value, int $indent = 0): string
-    {
-        if (is_array($value)) {
-            if ($value === []) {
-                return '[]';
-            }
-
-            $indentStr     = str_repeat('    ', $indent);
-            $nextIndentStr = str_repeat('    ', $indent + 1);
-            $lines         = [];
 
     private static function controllerNamespaceFromRel(string $baseNamespace, string $controllerRel, ?string $subfolder): string
     {
@@ -274,50 +57,73 @@ class {$className} extends TestCase
         $ns  = $baseNamespace . '\\' . $rel;
         if ($subfolder) {
             $ns .= '\\' . str_replace(['/', '\\'], '\\', trim($subfolder, '/\\'));
-
         }
+
+        return $ns;
+    }
 
     private static function resolveFieldMetadata(string $modelFqcn, ?array $fields, string $baseNamespace): array
     {
         if (is_array($fields) && !empty($fields)) {
+            if (array_is_list($fields)) {
+                $indexed = [];
+                foreach ($fields as $field) {
+                    if (is_array($field) && isset($field['name'])) {
+                        $indexed[$field['name']] = $field;
+                    }
+                }
+                if (!empty($indexed)) {
+                    $fields = $indexed;
+                }
+            }
+
             $metadata = MigrationFieldParser::normaliseFieldMetadata($fields, $baseNamespace);
         } else {
             $fillable = self::getFillable($modelFqcn);
             $casts    = [];
+
             if (class_exists($modelFqcn)) {
                 $model = new $modelFqcn();
                 $casts = method_exists($model, 'getCasts') ? $model->getCasts() : [];
             }
+
             $metadata = [];
             foreach ($fillable as $field) {
                 $cast = $casts[$field] ?? null;
-                $metadata[$field] = [
+
+                $entry = [
                     'type'     => self::inferTypeFromName($field, $cast),
                     'cast'     => $cast,
                     'nullable' => true,
                     'unique'   => false,
                 ];
+
                 if (str_ends_with($field, '_id')) {
                     $related = Str::studly(str_replace(['-', '_'], ' ', substr($field, 0, -3)));
                     $related = str_replace(' ', '', $related);
-                    $metadata[$field]['foreign'] = [
+                    $entry['foreign'] = [
                         'table'         => null,
                         'references'    => 'id',
                         'related_model' => $baseNamespace . '\\Models\\' . $related,
                     ];
                 }
+
+                $metadata[$field] = $entry;
             }
         }
 
-        foreach ($metadata as &$meta) {
+        foreach ($metadata as $key => &$meta) {
             if (empty($meta['foreign'])) {
                 unset($meta['foreign']);
             }
             if (empty($meta['enum'])) {
                 unset($meta['enum']);
             }
-            if (!array_key_exists('cast', $meta) || $meta['cast'] === null) {
+            if (!array_key_exists('cast', $meta) || $meta['cast'] === null || $meta['cast'] === '') {
                 unset($meta['cast']);
+            }
+            if (isset($meta['type'])) {
+                $meta['type'] = (string) $meta['type'];
             }
         }
         unset($meta);
@@ -366,16 +172,21 @@ class {$className} extends TestCase
         if (!class_exists($modelFqcn)) {
             return [];
         }
-        $m = new $modelFqcn();
-        return method_exists($m, 'getFillable') ? $m->getFillable() : [];
+
+        $model = new $modelFqcn();
+
+        return method_exists($model, 'getFillable') ? $model->getFillable() : [];
     }
 
-
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
+    private static function exportArray(array $arr): string
+    {
+        if ($arr === []) {
+            return '[]';
         }
 
-        return var_export($value, true);
+        $items = array_map(static fn ($value) => var_export($value, true), $arr);
+
+        return '[' . implode(', ', $items) . ']';
     }
 
     private static function exportAssoc(array $arr, int $indentLevel = 0): string
@@ -384,28 +195,44 @@ class {$className} extends TestCase
             return '[]';
         }
 
-        $indent = str_repeat('    ', $indentLevel);
+        $indent     = str_repeat('    ', $indentLevel);
         $nextIndent = str_repeat('    ', $indentLevel + 1);
-        $lines = ['['];
+        $lines      = ['['];
 
         foreach ($arr as $key => $value) {
             $keyStr = is_int($key) ? '' : "'" . addslashes((string) $key) . "' => ";
+
             if (is_array($value)) {
-                $nested = self::exportAssoc($value, $indentLevel + 1);
-                $nestedLines = explode("\n", $nested);
+                $nested       = self::exportAssoc($value, $indentLevel + 1);
+                $nestedLines  = explode("\n", $nested);
                 $nestedLines[0] = $nextIndent . $keyStr . ltrim($nestedLines[0]);
-                for ($i = 1; $i < count($nestedLines); $i++) {
+                for ($i = 1, $count = count($nestedLines); $i < $count; $i++) {
                     $nestedLines[$i] = $nextIndent . $nestedLines[$i];
                 }
                 $nestedLines[count($nestedLines) - 1] .= ',';
                 $lines = array_merge($lines, $nestedLines);
-            } else {
-                $lines[] = $nextIndent . $keyStr . var_export($value, true) . ',';
+                continue;
             }
+
+            $lines[] = $nextIndent . $keyStr . self::exportValue($value) . ',';
         }
 
         $lines[] = $indent . ']';
+
         return implode("\n", $lines);
+    }
+
+    private static function exportValue(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return var_export($value, true);
     }
 
     private static function writeFile(string $path, string $contents, bool $force): bool

--- a/src/Stubs/Module/Test/feature.stub
+++ b/src/Stubs/Module/Test/feature.stub
@@ -17,39 +17,55 @@ class {{ class }} extends TestCase
     {
         parent::setUp();
 
-        // روت‌های آزمایشی مستقل از روت‌های پروژه
         Route::middleware('api')->group(function () {
             Route::apiResource('{{ test_route_segment }}', \{{ controller_fqcn }}::class);
         });
     }
 
-    /**
-     * فیلدهای fillable مدل
-     */
     private function fillable(): array
     {
         return {{ fillable_export }};
     }
 
-    /**
-     * ساخت payload معتبر/نسبتاً معتبر برای store/update
-     * خروجی: [payload, canCreate]
-     */
+    private function fieldMetadata(): array
+    {
+        return {{ field_metadata_export }};
+    }
+
+    private function uniqueField(): ?string
+    {
+        foreach ($this->fieldMetadata() as $field => $meta) {
+            if (!empty($meta['unique'])) {
+                return $field;
+            }
+        }
+
+        foreach ($this->fillable() as $field) {
+            if ($field === 'slug' || str_contains($field, 'slug')) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
     private function buildValidPayload(bool $forCreate = true): array
     {
         $payload = [];
         $canCreate = true;
+        $metadata = $this->fieldMetadata();
 
         foreach ($this->fillable() as $field) {
             if (str_ends_with($field, '_at')) {
                 continue;
             }
-            if (str_ends_with($field, '_id')) {
-                $base = substr($field, 0, -3);
-                $related = {{ base_namespace_literal }} . '\\Models\\' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $base)));
 
+            $meta = $metadata[$field] ?? [];
+
+            if (!empty($meta['foreign']['related_model'])) {
+                $related = $meta['foreign']['related_model'];
                 $id = null;
-                if (class_exists($related)) {
+                if (is_string($related) && class_exists($related)) {
                     if (method_exists($related, 'factory')) {
                         $id = $related::factory()->create()->getKey();
                     } else {
@@ -60,8 +76,8 @@ class {{ class }} extends TestCase
                             foreach ($fill as $f) {
                                 if (str_ends_with($f, '_id')) { continue; }
                                 if (stripos($f, 'email') !== false) { $data[$f] = 'x'.uniqid().'@example.test'; continue; }
-                                if (stripos($f, 'slug')  !== false) { $data[$f] = 'slug-'.uniqid(); continue; }
-                                if (stripos($f, 'name')  !== false) { $data[$f] = 'Name '.uniqid(); continue; }
+                                if (stripos($f, 'slug') !== false) { $data[$f] = 'slug-'.uniqid(); continue; }
+                                if (stripos($f, 'name') !== false) { $data[$f] = 'Name '.uniqid(); continue; }
                                 if (stripos($f, 'price') !== false || stripos($f, 'amount') !== false) { $data[$f] = 1; continue; }
                                 if (stripos($f, 'is_') === 0 || stripos($f, 'has_') === 0) { $data[$f] = true; continue; }
                                 $data[$f] = 'val';
@@ -79,22 +95,63 @@ class {{ class }} extends TestCase
                 continue;
             }
 
-            if (stripos($field, 'email') !== false) {
-                $payload[$field] = 'u'.uniqid().'@example.test';
-            } elseif (stripos($field, 'slug') !== false || stripos($field, 'code') !== false) {
-                $payload[$field] = 'slug-'.uniqid();
-            } elseif (stripos($field, 'name') !== false || stripos($field, 'title') !== false) {
-                $payload[$field] = 'Title '.uniqid();
-            } elseif (stripos($field, 'price') !== false || stripos($field, 'amount') !== false || stripos($field, 'rate') !== false) {
-                $payload[$field] = 1000;
-            } elseif (stripos($field, 'is_') === 0 || stripos($field, 'has_') === 0) {
-                $payload[$field] = true;
-            } else {
-                $payload[$field] = 'text';
-            }
+            $payload[$field] = $this->fakeValueForField($field, $meta);
         }
 
         return [$payload, $canCreate];
+    }
+
+    private function fakeValueForField(string $field, array $meta): mixed
+    {
+        if (!empty($meta['enum']) && is_array($meta['enum'])) {
+            return $meta['enum'][0];
+        }
+
+        $cast = $meta['cast'] ?? null;
+        if (is_string($cast) && str_contains($cast, ':')) {
+            $cast = strtolower(strtok($cast, ':'));
+        }
+        $type = $meta['type'] ?? null;
+
+        if (stripos($field, 'email') !== false) {
+            return 'u'.uniqid().'@example.test';
+        }
+        if (stripos($field, 'slug') !== false || stripos($field, 'code') !== false) {
+            return 'slug-'.uniqid();
+        }
+        if (stripos($field, 'name') !== false || stripos($field, 'title') !== false) {
+            return 'Title '.uniqid();
+        }
+        if (stripos($field, 'price') !== false || stripos($field, 'amount') !== false || stripos($field, 'rate') !== false) {
+            return 1000;
+        }
+        if (stripos($field, 'is_') === 0 || stripos($field, 'has_') === 0) {
+            return true;
+        }
+
+        if (in_array($type, ['boolean'], true) || in_array($cast, ['bool', 'boolean'], true)) {
+            return true;
+        }
+        if (in_array($type, ['integer'], true) || in_array($cast, ['int', 'integer'], true)) {
+            return 1;
+        }
+        if (in_array($type, ['float', 'decimal'], true) || in_array($cast, ['float', 'double', 'decimal'], true)) {
+            return 1.0;
+        }
+        if (in_array($type, ['json'], true) || in_array($cast, ['array', 'collection'], true)) {
+            return ['sample' => 'data'];
+        }
+        if ($type === 'date') {
+            return '2024-01-01';
+        }
+        if ($type === 'datetime') {
+            return '2024-01-01 00:00:00';
+        }
+        if ($type === 'uuid') {
+            return 'uuid-'.uniqid();
+        }
+
+        return 'text';
     }
 
     private function createModel(): \{{ model_fqcn }}
@@ -102,7 +159,9 @@ class {{ class }} extends TestCase
         if (method_exists(\{{ model_fqcn }}::class, 'factory')) {
             return \{{ model_fqcn }}::factory()->create();
         }
-        [$payload, $can] = $this->buildValidPayload(true);
+
+        [$payload] = $this->buildValidPayload(true);
+
         return \{{ model_fqcn }}::query()->create($payload);
     }
 
@@ -130,12 +189,13 @@ class {{ class }} extends TestCase
 
     public function test_store_returns_validation_error_for_duplicate_unique_when_applicable(): void
     {
-        if (!in_array('slug', $this->fillable(), true)) {
-            $this->markTestSkipped('no unique-like field (slug) to test duplication');
+        $uniqueField = $this->uniqueField();
+        if (!$uniqueField) {
+            $this->markTestSkipped('no unique-like field to test duplication');
         }
         $existing = $this->createModel();
-        [$payload, $can] = $this->buildValidPayload(true);
-        $payload['slug'] = $existing->slug;
+        [$payload] = $this->buildValidPayload(true);
+        $payload[$uniqueField] = $existing->{$uniqueField};
         $res = $this->postJson($this->baseUri, $payload);
         $res->assertStatus(422);
     }
@@ -156,7 +216,7 @@ class {{ class }} extends TestCase
     public function test_update_updates_resource_with_valid_data(): void
     {
         $model = $this->createModel();
-        [$payload, $can] = $this->buildValidPayload(false);
+        [$payload] = $this->buildValidPayload(false);
         foreach ($payload as $k => $v) {
             if (is_string($v) && !str_ends_with($k, '_id')) {
                 $payload[$k] = 'updated-' . uniqid();
@@ -169,12 +229,13 @@ class {{ class }} extends TestCase
 
     public function test_update_returns_validation_error_on_duplicate_unique_when_applicable(): void
     {
-        if (!in_array('slug', $this->fillable(), true)) {
-            $this->markTestSkipped('no unique-like field (slug) to test duplication on update');
+        $uniqueField = $this->uniqueField();
+        if (!$uniqueField) {
+            $this->markTestSkipped('no unique-like field to test duplication on update');
         }
         $a = $this->createModel();
         $b = $this->createModel();
-        $res = $this->patchJson($this->baseUri . '/' . $b->getKey(), ['slug' => $a->slug]);
+        $res = $this->patchJson($this->baseUri . '/' . $b->getKey(), [$uniqueField => $a->{$uniqueField}]);
         $res->assertStatus(422);
     }
 


### PR DESCRIPTION
## Summary
- rewrite the feature TestGenerator to render the stub template after normalising field metadata and exporting fillable data
- refresh the published feature test stub to use metadata-aware payload generation and unique-field detection helpers

## Testing
- php -l src/Generators/TestGenerator.php

------
https://chatgpt.com/codex/tasks/task_e_68d110e228308321806ed8811a51b10d