### PR TITLE
Align generated services and repositories with base contracts

### DIFF
--- a/src/Stubs/BaseRepositoryInterface.php
+++ b/src/Stubs/BaseRepositoryInterface.php
@@ -2,13 +2,15 @@
 
 namespace App\Repositories\Contracts;
 
+use Illuminate\Database\Eloquent\Model;
+
 interface BaseRepositoryInterface
 {
     public function getAll(): iterable;
 
-    public function find(int|string $id): mixed;
+    public function find(int|string $id): ?Model;
 
-    public function store(array $data): mixed;
+    public function store(array $data): Model;
 
     public function update(int|string $id, array $data): bool;
 

--- a/src/Stubs/BaseService.php
+++ b/src/Stubs/BaseService.php
@@ -2,17 +2,18 @@
 
 namespace App\Services;
 
+use App\Repositories\Contracts\BaseRepositoryInterface;
 use App\Services\Contracts\BaseServiceInterface;
 use BadMethodCallException;
 
 abstract class BaseService implements BaseServiceInterface
 {
     /**
-     * @param object $repository Concrete repository for the service.
+     * @param BaseRepositoryInterface $repository Concrete repository for the service.
      */
-    public function __construct(protected object $repository) {}
+    public function __construct(protected BaseRepositoryInterface $repository) {}
 
-    public function repository(): object
+    public function repository(): BaseRepositoryInterface
     {
         return $this->repository;
     }
@@ -58,7 +59,7 @@ abstract class BaseService implements BaseServiceInterface
     protected function callRepository(string $method, array $arguments = []): mixed
     {
         if (!method_exists($this->repository, $method)) {
-            throw new BadMethodCallException(sprintf('Repository method %s::%s not found.', $this->repository::class, $method));
+            throw new BadMethodCallException(sprintf('Repository method %s::%s not found.', get_class($this->repository), $method));
         }
 
         return $this->repository->{$method}(...$arguments);

--- a/src/Stubs/BaseServiceInterface.php
+++ b/src/Stubs/BaseServiceInterface.php
@@ -2,9 +2,11 @@
 
 namespace App\Services\Contracts;
 
+use App\Repositories\Contracts\BaseRepositoryInterface;
+
 interface BaseServiceInterface
 {
-    public function repository(): object;
+    public function repository(): BaseRepositoryInterface;
 
     public function index(): mixed;
 

--- a/src/Stubs/Module/Repository/concrete.stub
+++ b/src/Stubs/Module/Repository/concrete.stub
@@ -2,42 +2,33 @@
 
 namespace {{ namespace }};
 
-use {{ interface_fqcn }};
-use {{ base_repository_fqcn }};
-use {{ model_fqcn }};
-use Illuminate\Database\Eloquent\Model;
+{{ uses }}
 
 class {{ class }} extends BaseRepository implements {{ interface }}
 {
-    public function __construct(public {{ model }} $model)
+    public function __construct({{ model }} $model)
     {
-        parent::__construct($this->model);
+        parent::__construct($model);
     }
 
-    public function getAll()
+    /**
+     * @return iterable<{{ model }}>
+     */
+    public function getAll(): iterable
     {
-        return $this->model->query()->latest()->get();
+        /** @var iterable<{{ model }}> */
+        return parent::getAll();
     }
 
-    public function find(int $id): ?Model
+    public function find(int|string $id): ?{{ model }}
     {
-        return $this->model->find($id);
+        /** @var {{ model }}|null */
+        return parent::find($id);
     }
 
-    public function store(array $data): Model
+    public function store(array $data): {{ model }}
     {
-        return $this->model->create($data);
-    }
-
-    public function update(int $id, array $data): bool
-    {
-        $item = $this->find($id);
-        return $item ? $item->update($data) : false;
-    }
-
-    public function delete(int $id): bool
-    {
-        $item = $this->find($id);
-        return $item ? (bool) $item->delete() : false;
+        /** @var {{ model }} */
+        return parent::store($data);
     }
 }

--- a/src/Stubs/Module/Repository/contract.stub
+++ b/src/Stubs/Module/Repository/contract.stub
@@ -2,13 +2,20 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Database\Eloquent\Model;
+{{ uses }}
 
-interface {{ interface }}
+interface {{ interface }} extends BaseRepositoryInterface
 {
-    public function getAll();
-    public function find(int $id): ?Model;
-    public function store(array $data): Model;
-    public function update(int $id, array $data): bool;
-    public function delete(int $id): bool;
+    /**
+     * @return iterable<{{ model }}>
+     */
+    public function getAll(): iterable;
+
+    public function find(int|string $id): ?{{ model }};
+
+    public function store(array $data): {{ model }};
+
+    public function update(int|string $id, array $data): bool;
+
+    public function delete(int|string $id): bool;
 }

--- a/src/Stubs/Module/Service/concrete.stub
+++ b/src/Stubs/Module/Service/concrete.stub
@@ -6,33 +6,30 @@ namespace {{ namespace }};
 
 class {{ class }} extends BaseService implements {{ interface }}
 {
-    public function __construct(public {{ repository_type }} $repository)
+    public function __construct({{ repository_type_hint }} $repository)
     {
-        parent::__construct($this->repository);
+        parent::__construct($repository);
     }
 
-    public function index()
+    /**
+     * @return iterable<{{ model }}>
+     */
+    public function index(): iterable
     {
-        return $this->repository->getAll();
+        /** @var iterable<{{ model }}> */
+        return parent::index();
     }
 
-    public function show(int $id): ?Model
+    public function show(int|string $id): ?{{ model }}
     {
-        return $this->repository->find($id);
+        /** @var {{ model }}|null */
+        return parent::show($id);
     }
 
-    public function store({{ store_argument }}): Model
+{{ store_method }}
+{{ update_method }}
+    public function destroy(int|string $id): bool
     {
-{{ store_body }}
-    }
-
-    public function update(int $id, {{ update_argument }}): bool
-    {
-{{ update_body }}
-    }
-
-    public function destroy(int $id): bool
-    {
-        return $this->repository->delete($id);
+        return parent::destroy($id);
     }
 }

--- a/src/Stubs/Module/Service/interface.stub
+++ b/src/Stubs/Module/Service/interface.stub
@@ -4,11 +4,16 @@ namespace {{ namespace }};
 
 {{ uses }}
 
-interface {{ interface }}
+interface {{ interface }} extends BaseServiceInterface
 {
-    public function index();
-    public function show(int $id): ?Model;
-    {{ store_signature }}
-    {{ update_signature }}
-    public function destroy(int $id): bool;
+    /**
+     * @return iterable<{{ model }}>
+     */
+    public function index(): iterable;
+
+    public function show(int|string $id): ?{{ model }};
+
+{{ store_method }}
+{{ update_method }}
+    public function destroy(int|string $id): bool;
 }


### PR DESCRIPTION
## Summary
- type BaseService against BaseRepositoryInterface and adjust the shared contracts
- update the service generator and stubs to honour the base method signatures while still handling DTO payloads
- update the repository generator and stubs so generated repositories extend the base interface and return the concrete model types

## Testing
- `vendor/bin/phpunit` *(fails: binary not present in package)*

------
https://chatgpt.com/codex/tasks/task_e_68d1139483408321936ce33eac500004