### PR TITLE
Add documentation IA plan

### DIFF
--- a/docs/ia.md
+++ b/docs/ia.md
@@ -1,0 +1,51 @@
+# Documentation Information Architecture
+
+## 1. Page Inventory
+- **Home**
+- **Installation**
+- **Configuration**
+- **Usage**
+- **Advanced Features**
+- **Changelog**
+- **FAQ**
+
+## 2. Page Objectives, Core Messages, and Calls to Action
+| Page | Primary User Goal | Core Message | Key CTAs |
+| --- | --- | --- | --- |
+| Home | Understand what Laravel Module Generator offers and why it matters | "Generate Laravel modules quickly with consistent scaffolding to speed up development." | • Explore Installation<br>• View Advanced Features<br>• Read Success Stories (link to Usage) |
+| Installation | Install the package successfully in a project | "Installation is straightforward with Composer and quick configuration steps." | • Copy Composer Command<br>• Jump to Configuration |
+| Configuration | Configure package defaults and publish assets | "Tailor the generator to your project by publishing configs and adjusting options." | • Follow Configuration Checklist<br>• Proceed to Usage |
+| Usage | Learn how to generate modules and understand commands | "Use the generator commands to scaffold modules, models, and supporting assets." | • Run First Module Command<br>• Download CLI Cheat Sheet |
+| Advanced Features | Discover extensibility and customization options | "Extend the generator with templates, hooks, and integration points for complex projects." | • Read Extension Guide<br>• Watch Advanced Demo |
+| Changelog | Track release history and updates | "Stay informed about fixes, improvements, and breaking changes." | • Subscribe to Release Notes<br>• Compare Versions |
+| FAQ | Resolve common questions without contacting support | "Find quick answers about installation, configuration, and usage scenarios." | • Search FAQs<br>• Contact Support |
+
+## 3. Navigation & Footer Wireframe Notes
+```
+Top Navigation (Desktop)
+┌────────────────────────────────────────────────────────────┐
+│ Logo | Home | Installation | Configuration | Usage | Advanced Features | Changelog | FAQ | CTA Button: Get Started │
+└────────────────────────────────────────────────────────────┘
+
+Mobile Navigation (Drawer)
+┌──────────────┐
+│ Logo    ☰    │
+├──────────────┤
+│ Home          │
+│ Installation  │
+│ Configuration │
+│ Usage         │
+│ Advanced Features │
+│ Changelog     │
+│ FAQ           │
+│ Get Started CTA │
+└──────────────┘
+
+Footer Layout
+┌────────────────────────────────────────────────────────────┐
+│ Logo & Tagline | Quick Links (Home, Installation, Usage) | Resources (Advanced Features, Changelog, FAQ) | Stay Connected (Newsletter CTA, GitHub link) │
+│ Legal: © YEAR Company Name · Privacy · Terms │
+└────────────────────────────────────────────────────────────┘
+```
+
+*These sketches serve as a pre-implementation reference for stakeholder review.*


### PR DESCRIPTION
## Summary
- add information architecture outline covering key documentation pages
- define page goals, core messages, and calls to action for each page
- sketch navigation and footer wireframes for review prior to implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66beb1bd0832194531caa5987620f