### PR TITLE
Add installation documentation and update navigation plan

### DIFF
--- a/docs/ia.md
+++ b/docs/ia.md
@@ -24,7 +24,8 @@
 ```
 Top Navigation (Desktop)
 ┌────────────────────────────────────────────────────────────┐
-│ Logo | Home | Installation | Configuration | Usage | Advanced Features | Changelog | FAQ | CTA Button: Get Started │
+│ Logo | Getting Started ▾ | Configuration | Usage | Advanced Features | Changelog | FAQ | CTA Button: Get Started │
+│             └ Installation                                 │
 └────────────────────────────────────────────────────────────┘
 
 Mobile Navigation (Drawer)
@@ -32,7 +33,8 @@ Mobile Navigation (Drawer)
 │ Logo    ☰    │
 ├──────────────┤
 │ Home          │
-│ Installation  │
+│ Getting Started │
+│   • Installation │
 │ Configuration │
 │ Usage         │
 │ Advanced Features │

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,35 @@
+# Installation
+
+Get up and running with the Laravel Module Generator in just a few commands. Start by pulling in the package via Composer and then publish the configuration so you can tailor the generator to your application's structure.
+
+## Require the package
+
+```bash
+composer require efati/laravel-module-generator
+```
+
+## Publish the configuration
+
+```bash
+php artisan vendor:publish --tag=module-generator-config
+```
+
+Publishing the configuration adds `config/module-generator.php` to your project. This file controls the namespace and path defaults for every artefact the generator can create.
+
+## Configure namespaces and paths
+
+Inside `config/module-generator.php` you can point each component—models, repositories, services, controllers, DTOs, tests, and more—to the folders and namespaces that match your project's architecture. Update the values in the `namespaces` and `paths` sections so newly generated classes land exactly where you expect them.
+
+## Customise generator stubs
+
+If you need the generated files to follow team-specific conventions, publish the stubs and edit them to match your preferred structure:
+
+```bash
+php artisan vendor:publish --tag=module-generator-stubs
+```
+
+The command copies every stub to `resources/stubs/module-generator`, where you can update imports, docblocks, method signatures, or any other scaffolding details. The generator will read from your customised stubs on subsequent runs, so your adjustments take effect immediately.
+
+---
+
+[← Back to Configuration](../README.md#configuration)


### PR DESCRIPTION
## Summary
- add a dedicated installation guide with composer and artisan commands plus guidance on namespaces and stub customisation
- update the documentation IA navigation to list Installation under the Getting Started section

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d66db7ddb08321989bc1603b1f772c