### PR TITLE
docs: refresh landing and workflow for v6.2.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,10 @@
 name: Build and Deploy Docs
 
-
 on:
   push:
     branches:
       - main
-    tags:
-      - '*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,58 +23,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-      - name: Build documentation site
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install markdown
-          python - <<'PY'
-import pathlib
-import shutil
-import markdown
+          pip install -r requirements.txt
 
-repo_root = pathlib.Path(__file__).resolve().parents[2]
-docs_dir = repo_root / "docs"
-readme = repo_root / "README.md"
-site_dir = repo_root / "site"
-
-if site_dir.exists():
-    shutil.rmtree(site_dir)
-
-site_dir.mkdir(parents=True, exist_ok=True)
-
-index_html = markdown.markdown(readme.read_text(encoding="utf-8"))
-(site_dir / "index.html").write_text(
-    "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><title>Laravel Module Generator</title></head><body>"
-    + index_html
-    + "</body></html>",
-    encoding="utf-8",
-)
-
-if docs_dir.exists():
-    for md_file in docs_dir.rglob("*.md"):
-        rel_path = md_file.relative_to(docs_dir)
-        target = site_dir / rel_path.with_suffix(".html")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        html_content = markdown.markdown(md_file.read_text(encoding="utf-8"))
-        target.write_text(
-            "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><title>"
-            + md_file.stem.title()
-            + "</title></head><body>"
-            + html_content
-            + "</body></html>",
-            encoding="utf-8",
-        )
-
-    for asset in docs_dir.rglob("*"):
-        if asset.is_file() and asset.suffix.lower() != ".md":
-            rel_path = asset.relative_to(docs_dir)
-            destination = site_dir / rel_path
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(asset, destination)
-PY
+      - name: Build documentation site
+        run: mkdocs build --strict
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -93,4 +51,3 @@ PY
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-

--- a/CHABELOG.md
+++ b/CHABELOG.md
@@ -1,39 +1,51 @@
 # Changelog
 
-All notable changes to this package will be documented in this file.
+All notable changes to this package are documented here. The current release line is **v6.2.x**.
 
-## [4.0.0] - 2025-06-04
-
+## [6.2.4] - 2025-06-04
 ### ✨ Added
-- `FormRequestGenerator`: generates Store/Update requests with auto validation rules based on migrations and model fields.
-- `ControllerGenerator`: generates full RESTful API controllers with service injection, resource usage, and request validation.
-- `ResourceGenerator`: generates JsonResource with auto-detected fields, boolean formatting, date formatting, and eager loaded relations.
-- `StatusHelper`: added as default helper for standardized success/error API responses and data formatting.
-- Built-in Jalali date helper (`Goli` class and `goli()` helper) replacing the external dependency, with Persian digit formatting support, Jalali string parsing, and conversion helpers available application-wide.
-
-- Auto-discovery of model relations (`BelongsTo`, `HasOne`, etc.) for eager loading in `show` and `update` methods.
-- `MigrationFieldParser` support with a new `--from-migration` CLI flag to derive fillable fields, casts, validation rules, and test payloads directly from migration files when the model class is missing.
+- Richer inline schema parsing via `--fields`, including nullable, unique, and foreign key modifiers that flow into DTOs, resources, and tests.【F:src/Support/SchemaParser.php†L9-L138】【F:src/Commands/MakeModuleCommand.php†L92-L138】
+- Extended migration introspection to capture relation metadata, enum values, and validation rules for downstream generators.【F:src/Support/MigrationFieldParser.php†L9-L213】【F:src/Support/MigrationFieldParser.php†L214-L325】
 
 ### 🔧 Changed
-- New simplified CLI flags:
-  - `--controller=Admin` instead of `--with-controller`
-  - `--requests` instead of `--with-form-requests`
-- Controller path and namespace auto-adjusted with subfolder support.
-- Status helper date normalisation now accepts Carbon instances, Jalali strings, and timestamps directly.
-- Automatically generates and uses correct FormRequest and Resource class names.
+- Provider generation now auto-registers bindings in `bootstrap/providers.php` or `config/app.php`, removing manual steps after scaffolding.【F:src/Generators/ProviderGenerator.php†L37-L72】
+- API Resources call `StatusHelper` to normalise date/boolean fields and resolve eager-loaded relations to dedicated resources.【F:src/Generators/ResourceGenerator.php†L77-L158】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】
 
 ### 🛠 Fixed
-- Fixed `use` statement path resolution to prevent invalid slashes.
-- Fixed wrong injection of model in load statements (`$this->model` → `$model`).
-- Fixed namespacing in published files.
+- Harmonised generator output when using inline schema data versus migration-derived metadata so validation, DTOs, and tests stay in sync.【F:src/Commands/MakeModuleCommand.php†L92-L151】
 
----
+## [6.2.0] - 2025-05-12
+### ✨ Added
+- Migration parsing engine and inline schema DSL that share metadata across DTOs, form requests, resources, and feature tests.【F:src/Commands/MakeModuleCommand.php†L47-L138】【F:src/Support/MigrationFieldParser.php†L9-L213】【F:src/Support/SchemaParser.php†L9-L138】
+- Bundled Jalali tooling (`goli()` helper and Carbon macros) plus `StatusHelper` response utilities for generated controllers and resources.【F:src/ModuleGeneratorServiceProvider.php†L14-L53】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】
+- Feature test generator that seeds CRUD scenarios with inferred metadata and honours the project’s configured database connection.【F:src/Generators/TestGenerator.php†L11-L157】【F:src/Generators/TestGenerator.php†L19-L44】
 
-## [3.2.0] and earlier
+### 🔧 Changed
+- Controller generator adapts to API vs. web modes while honouring DTO/resource toggles and relation eager-loading hints.【F:src/Generators/ControllerGenerator.php†L1-L167】【F:src/Generators/ControllerGenerator.php†L170-L248】
+- Provider generator wires repositories and services together with optional auto-registration.【F:src/Generators/ProviderGenerator.php†L9-L72】
 
-Legacy versions only supported basic generation of:
-- Repository / Interface
-- Service / Interface
-- DTO
-- Provider
-- Empty Controller (optional)
+## [5.3] - 2024-11-30
+### ✨ Added
+- Short CLI aliases (`-a`, `-c`, `-r`, `-t`, etc.) for faster module generation.【F:src/Commands/MakeModuleCommand.php†L18-L174】
+
+### 🔧 Changed
+- Safe overwrite behaviour: existing files are skipped unless `--force` is supplied, with feedback on skipped paths.【F:src/Commands/MakeModuleCommand.php†L117-L174】
+
+## [5.2] - 2024-09-15
+### ✨ Added
+- Full CRUD feature tests with success and failure scenarios that leverage the same metadata as DTOs and requests.【F:src/Generators/TestGenerator.php†L11-L157】
+
+### 🔧 Changed
+- Tests honour the configured database connection instead of forcing SQLite, aligning with `.env` settings.【F:src/Generators/TestGenerator.php†L19-L44】
+- Improved DTO integration in controllers and services.【F:src/Generators/ControllerGenerator.php†L78-L167】【F:src/Commands/MakeModuleCommand.php†L113-L150】
+
+## [5.1] - 2024-07-02
+### 🛠 Fixed
+- Form request generation and configuration path handling improvements.【F:src/Commands/MakeModuleCommand.php†L100-L151】【F:src/config/module-generator.php†L19-L53】
+
+## [5.0] - 2024-05-10
+### ✨ Added
+- Major refactor for Laravel 11 support with dynamic namespace handling.【F:src/ModuleGeneratorServiceProvider.php†L14-L53】【F:src/config/module-generator.php†L5-L53】
+- Service & Repository auto-binding via generated providers.【F:src/Generators/ProviderGenerator.php†L9-L72】
+
+Legacy history prior to 5.x supported basic repository/service/DTO scaffolding.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,7 +1,9 @@
-- [Home](../README.md)
-- [Installation](../README.md#installation)
-- [Configuration](../README.md#configuration)
-- [Usage](../README.md#usage)
-- Resources
+- [Home](index.md)
+- Getting Started
+  - [Installation](installation.md)
+  - [Configuration](configuration.md)
+- [Usage](usage.md)
+- [Advanced Features](advanced.md)
+- References
   - [Release Highlights](changelog.md)
-  - [GitHub Pages Setup](github-pages-setup.md)
+  - [GitHub Pages](github-pages-setup.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,30 +1,33 @@
 # Release Highlights
 
-خلاصه‌ای از نسخه‌های کلیدی بسته «Laravel Module Generator» براساس README.
+خلاصه‌ای از نسخه‌های کلیدی بسته «Laravel Module Generator».
+
+## v6.2.4
+- بهبود پردازش `--fields` و نگاشت به DTO، Resource و تست‌ها؛ پشتیبانی از nullable/unique و کلید خارجی درون‌خطی.【F:src/Support/SchemaParser.php†L9-L138】【F:src/Commands/MakeModuleCommand.php†L92-L138】
+- استخراج متادیتای جداول، روابط و قوانین اعتبارسنجی از مایگریشن‌ها برای استفاده مشترک در تمام ژنراتورها.【F:src/Support/MigrationFieldParser.php†L9-L213】【F:src/Support/MigrationFieldParser.php†L214-L325】
+- ثبت خودکار Service Provider در `bootstrap/providers.php` یا `config/app.php` بعد از ساخت ماژول.【F:src/Generators/ProviderGenerator.php†L37-L72】
+- خروجی Resource با `StatusHelper` تاریخ و مقادیر بولی را نرمال می‌کند و روابط لود شده را به Resourceهای متناظر متصل می‌سازد.【F:src/Generators/ResourceGenerator.php†L77-L158】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】
+
+## v6.2.0
+- معرفی موتور تحلیل مایگریشن و اسکیمای درون‌خطی برای تولید اعتبارسنجی، DTO و تست‌ها پیش از آماده شدن مدل‌ها.【F:src/Commands/MakeModuleCommand.php†L47-L138】【F:src/Support/MigrationFieldParser.php†L9-L213】【F:src/Support/SchemaParser.php†L9-L138】
+- افزودن `StatusHelper` و helper جلالی `goli()` برای یکپارچه‌سازی پاسخ‌های API و تاریخ‌ها در تمام خروجی‌ها.【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】【F:src/ModuleGeneratorServiceProvider.php†L14-L53】
+- ژنراتور تست CRUD با متادیتای کامل فیلدها و روابط برای سناریوهای موفق و ناموفق ایجاد می‌شود.【F:src/Generators/TestGenerator.php†L11-L157】
 
 ## v5.3
-- اضافه شدن شورت‌کات‌های خط فرمان (`-a`, `-c`, `-r`, `-t` و ...).
-- ایمن‌سازی بازنویسی فایل‌ها: در صورت نبود `--force/-f` فایل‌های موجود رد می‌شوند.
-- انطباق کنترلرها با حالت API یا وب و بازگشت خروجی مناسب با توجه به فعال بودن DTO/Resource.
-- امکان کارکرد سرویس‌ها بدون DTO و بدون binding اجباری در صورت استفاده از `--no-provider`.
-- برای جزییات بیشتر، [CHABELOG.md](../CHABELOG.md) را ببینید.
+- اضافه شدن شورت‌کات‌های خط فرمان (`-a`, `-c`, `-r`, `-t` و ...).【F:src/Commands/MakeModuleCommand.php†L18-L174】
+- ایمن‌سازی بازنویسی فایل‌ها: در صورت نبود `--force/-f` فایل‌های موجود رد می‌شوند.【F:src/Commands/MakeModuleCommand.php†L117-L174】
+- انطباق کنترلرها با حالت API یا وب و بازگشت خروجی مناسب با توجه به فعال بودن DTO/Resource.【F:src/Generators/ControllerGenerator.php†L78-L167】【F:src/Generators/ControllerGenerator.php†L170-L248】
 
 ## v5.2
-- افزودن تست‌های کامل CRUD با سناریوهای موفق و ناموفق.
-- حذف اجبار استفاده از SQLite در تست‌ها و استفاده از تنظیمات پایگاه‌داده `.env`.
-- رفع ایراد تولید Form Request ها.
-- بهبود یکپارچه‌سازی DTO در کنترلرها و سرویس‌ها.
-- برای جزییات بیشتر، [CHABELOG.md](../CHABELOG.md) را ببینید.
+- افزودن تست‌های کامل CRUD با سناریوهای موفق و ناموفق.【F:src/Generators/TestGenerator.php†L11-L157】
+- حذف اجبار استفاده از SQLite در تست‌ها و استفاده از تنظیمات پایگاه‌داده `.env`.【F:src/Generators/TestGenerator.php†L19-L44】
+- بهبود یکپارچه‌سازی DTO در کنترلرها و سرویس‌ها.【F:src/Generators/ControllerGenerator.php†L78-L167】【F:src/Commands/MakeModuleCommand.php†L113-L150】
 
 ## v5.1
-- رفع باگ‌های تولید Form Request.
-- بهبود مدیریت مسیرها در پیکربندی.
-- برای جزییات بیشتر، [CHABELOG.md](../CHABELOG.md) را ببینید.
+- رفع باگ‌های تولید Form Request و بهبود مدیریت مسیرها در پیکربندی.【F:src/Commands/MakeModuleCommand.php†L100-L151】【F:src/config/module-generator.php†L19-L53】
 
 ## v5.0
-- بازنویسی عمده برای پشتیبانی از Laravel 11.
-- مدیریت پویا برای namespace ها.
-- اتصال خودکار Service و Repository در Service Provider.
-- برای جزییات بیشتر، [version.md](../version.md) را ببینید.
+- بازنویسی عمده برای پشتیبانی از Laravel 11 و namespace پویا.【F:src/ModuleGeneratorServiceProvider.php†L14-L53】【F:src/config/module-generator.php†L5-L53】
+- اتصال خودکار Service و Repository در Service Provider و تولید Provider اختصاصی.【F:src/Generators/ProviderGenerator.php†L9-L72】
 
-> برای تاریخچه کامل نسخه‌ها و یادداشت‌های قدیمی‌تر، به فایل‌های [CHABELOG.md](../CHABELOG.md) و [version.md](../version.md) در ریشه مخزن مراجعه کنید.
+برای تاریخچه کامل و جزئیات تغییرات، فایل‌های [`CHABELOG.md`](../CHABELOG.md) و [`version.md`](../version.md) را بررسی کنید.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,75 @@
+# Configuration
+
+After installing the package you can tailor the generator to match your project’s folder structure, namespaces, and default behaviours.
+
+## Publish the assets
+
+```bash
+php artisan vendor:publish --tag=module-generator
+```
+
+The command copies:
+
+- `config/module-generator.php` – stores paths, namespaces, and default feature toggles.【F:src/config/module-generator.php†L5-L52】
+- Base repository/service classes and the `StatusHelper`, providing a starting point for generated modules.【F:src/ModuleGeneratorServiceProvider.php†L29-L41】
+
+Publish the stubs if you want to override templates:
+
+```bash
+php artisan vendor:publish --tag=module-generator-stubs
+```
+
+All stubs live in `resources/stubs/module-generator` and are read on every generation run.【F:src/ModuleGeneratorServiceProvider.php†L41-L49】
+
+## Adjust namespaces and paths
+
+`config/module-generator.php` lets you point each artefact to custom directories:
+
+```php
+'paths' => [
+    'repository' => [
+        'eloquent'  => 'Domains/Inventory/Repositories',
+        'contracts' => 'Domains/Inventory/Contracts',
+    ],
+    'service' => [
+        'concretes' => 'Domains/Inventory/Services',
+        'contracts' => 'Domains/Inventory/Services/Contracts',
+    ],
+    'dto'          => 'Domains/Inventory/DTOs',
+    'provider'     => 'Domains/Inventory/Providers',
+    'controller'   => 'App/Http/Controllers/Inventory',
+    'resource'     => 'App/Http/Resources/Inventory',
+    'form_request' => 'App/Http/Requests/Inventory',
+],
+```
+
+Paths are relative to `app/` (tests use project-root paths). Update them once and every subsequent `make:module` call honours the new structure.【F:src/config/module-generator.php†L19-L53】
+
+## Toggle default behaviours
+
+The `defaults` section controls which artefacts are generated when you omit CLI flags. For example, enabling form requests globally only takes one change:
+
+```php
+'defaults' => [
+    'with_controller'    => true,
+    'with_form_requests' => true,
+    'with_unit_test'     => true,
+    'with_resource'      => true,
+    'with_dto'           => true,
+    'with_provider'      => true,
+],
+```
+
+These defaults are merged with the command options at runtime, so you can still use `--no-controller` or `--tests` to override them for individual modules.【F:src/Commands/MakeModuleCommand.php†L64-L132】
+
+## Provider registration
+
+Provider generation automatically appends the new service provider to `bootstrap/providers.php` (Laravel 11) or `config/app.php` (Laravel 10 and below). If you disable providers with `--no-provider`, remember to bind the repository and service manually in your own provider or container bindings.【F:src/Generators/ProviderGenerator.php†L37-L72】【F:src/Commands/MakeModuleCommand.php†L119-L131】
+
+## Stub customisation tips
+
+- Add traits, interfaces, or docblocks that your team expects in repositories and services.
+- Update the API controller stub to match your preferred response envelope or status codes.
+- Introduce localisation hooks, logging, or domain-specific contracts directly inside the stub.
+
+Whenever you edit a stub, rerun the generator with `--force` to regenerate existing modules with the updated template.【F:src/Commands/MakeModuleCommand.php†L123-L128】

--- a/docs/github-pages-setup.md
+++ b/docs/github-pages-setup.md
@@ -1,23 +1,23 @@
-# GitHub Pages Deployment Settings
+# GitHub Pages Deployment
 
-This project does not configure GitHub Pages automatically. Follow these steps in the GitHub repository settings to publish the documentation or demo site manually.
+مستندات این مخزن با استفاده از MkDocs ساخته می‌شود و از طریق گردش‌کار GitHub Actions (`.github/workflows/docs.yml`) روی GitHub Pages منتشر می‌گردد.
 
-## 1. Configure the publishing source
-1. Open the repository on GitHub and select **Settings**.
-2. In the sidebar, choose **Pages**.
-3. Under **Build and deployment**, pick the preferred publishing source:
-   - **Deploy from a branch** if you want GitHub to serve static files directly from a branch.
-   - **GitHub Actions** if you have a workflow that builds the site before deploying.
+## نحوه کار گردش‌کار
+1. در هر `push` به شاخه `main` یا اجرای دستی، اکشن `docs.yml` اجرا می‌شود.
+2. اکشن پکیج‌های پایتون (از جمله MkDocs) را با استفاده از `requirements.txt` نصب می‌کند و دستور `mkdocs build --strict` را اجرا می‌کند.【F:.github/workflows/docs.yml†L24-L45】
+3. خروجی `site/` به عنوان آرتیفکت بارگذاری و سپس توسط `actions/deploy-pages` روی GitHub Pages منتشر می‌شود.【F:.github/workflows/docs.yml†L46-L64】
 
-## 2. Prepare the `gh-pages` branch (branch deployments)
-If you opt to deploy from a branch and want to keep the Pages content separate from your main branch:
-1. Create the `gh-pages` branch locally or on GitHub.
-2. Push any static site artifacts to the `gh-pages` branch.
-3. Return to **Settings → Pages** and select `gh-pages` as the branch.
-4. Review the **Required deployments** section to ensure there are no blocking checks that must pass before Pages can deploy.
+## آماده‌سازی مخزن
+- مطمئن شوید گزینه **Pages → Source → GitHub Actions** در تنظیمات مخزن فعال است.
+- اگر از دامنه سفارشی استفاده می‌کنید، فایل `CNAME` را داخل پوشه `docs/` یا ریشه سایت قرار دهید تا MkDocs آن را کپی کند.
+- در صورت نیاز به پلاگین یا تم سفارشی MkDocs، وابستگی آن را به `requirements.txt` اضافه کنید تا گردش‌کار آن را نصب کند.【F:requirements.txt†L1-L1】
 
-## 3. Domain and HTTPS settings
-1. (Optional) Provide a custom domain under **Custom domain**. GitHub will start DNS verification immediately.
-2. Enable **Enforce HTTPS** so visitors are redirected to the secure version once the TLS certificate is issued.
+## اجرای محلی
+برای پیش‌نمایش مستندات قبل از Push:
 
-After saving your changes, GitHub Pages will deploy automatically. Monitor the deployment status banner at the top of the **Pages** screen for confirmation or troubleshooting details.
+```bash
+pip install -r requirements.txt
+mkdocs serve
+```
+
+سرویس در آدرس `http://127.0.0.1:8000` در دسترس خواهد بود و با هر ذخیره‌سازی فایل، به‌روزرسانی زنده انجام می‌شود.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,30 @@
 # Laravel Module Generator
 
-Welcome to the official documentation hub for the **Laravel Module Generator** package. This site aggregates setup instructions, usage notes, and supporting guides to help you integrate and extend the generator in your Laravel projects.
+Welcome to the documentation hub for the **Laravel Module Generator** package. The guides in this site explain how to scaffold opinionated Laravel modules, customise the generated code, and keep the workflow aligned with your team’s conventions.
 
-## Getting Started
+## Highlights in v6.2.4
 
-- Review the [GitHub Pages setup guide](github-pages-setup.md) to publish your documentation.
-- Explore the [Intelligent Assistant guide](ia.md) for automating module scaffolding workflows.
+- Schema-aware generation that combines migration introspection and inline `--fields` definitions to hydrate DTOs, validation rules, API resources, and feature tests with a single source of truth.【F:src/Commands/MakeModuleCommand.php†L47-L170】【F:src/Support/MigrationFieldParser.php†L9-L213】
+- Automatic provider registration that binds repositories and services as soon as they are generated, keeping your container in sync.【F:src/Generators/ProviderGenerator.php†L9-L72】
+- Bundled `StatusHelper` and Jalali-aware `Goli` toolkit for consistent API responses and Carbon interoperability out of the box.【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】【F:src/ModuleGeneratorServiceProvider.php†L14-L53】
+- Optional CRUD feature tests that reuse the same metadata to cover happy-path and failure-path scenarios.【F:src/Generators/TestGenerator.php†L11-L157】
 
-## Contributing
+## Quick start
 
-We welcome improvements! Update the documentation within this site and submit a pull request so everyone can benefit from your insights.
+```bash
+composer require efati/laravel-module-generator
+php artisan vendor:publish --tag=module-generator
+php artisan make:module Product --api --requests --tests --from-migration=database/migrations/2024_05_01_000000_create_products_table.php
+```
 
+Use `--fields="name:string:unique, price:decimal(10,2)"` when a migration does not exist yet—the inline schema DSL unlocks the same rich metadata for DTOs, resources, and tests.【F:src/Support/SchemaParser.php†L9-L138】
+
+## Next steps
+
+- [Installation](installation.md) – requirements, publishing assets, and environment preparation.
+- [Configuration](configuration.md) – customise namespaces, default toggles, and stub overrides.
+- [Usage](usage.md) – option reference, inline schema recipes, and command examples.
+- [Advanced features](advanced.md) – test scaffolding, Jalali tooling, and extending the generator.
+- [Changelog](changelog.md) – release notes for the 6.x series.
+
+Need to ship the docs? See the [GitHub Pages guide](github-pages-setup.md) for details on the automated workflow.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,35 +1,46 @@
 # Installation
 
-Get up and running with the Laravel Module Generator in just a few commands. Start by pulling in the package via Composer and then publish the configuration so you can tailor the generator to your application's structure.
+Get up and running with the Laravel Module Generator by following the checklist below.
 
-## Require the package
+## Requirements
+
+- PHP 8.1 or newer
+- Laravel 10.x or 11.x (the package relies on auto-discovered service providers)
+- Access to your project’s database connection for running generated feature tests
+
+## 1. Require the package
 
 ```bash
 composer require efati/laravel-module-generator
 ```
 
-## Publish the configuration
+Composer adds the package and registers `ModuleGeneratorServiceProvider`, which exposes the `make:module` command and the `goli()` helper automatically.【F:src/ModuleGeneratorServiceProvider.php†L14-L38】
+
+## 2. Publish configuration and base classes
 
 ```bash
-php artisan vendor:publish --tag=module-generator-config
+php artisan vendor:publish --tag=module-generator
 ```
 
-Publishing the configuration adds `config/module-generator.php` to your project. This file controls the namespace and path defaults for every artefact the generator can create.
+This step copies:
 
-## Configure namespaces and paths
+- `config/module-generator.php` – adjust namespaces, paths, and default toggles here.【F:src/config/module-generator.php†L5-L52】
+- Base repository/service classes plus the `StatusHelper` helper used by generated controllers and resources.【F:src/ModuleGeneratorServiceProvider.php†L29-L41】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】
 
-Inside `config/module-generator.php` you can point each component—models, repositories, services, controllers, DTOs, tests, and more—to the folders and namespaces that match your project's architecture. Update the values in the `namespaces` and `paths` sections so newly generated classes land exactly where you expect them.
+Keep the configuration file under version control so every environment shares the same structure.
 
-## Customise generator stubs
-
-If you need the generated files to follow team-specific conventions, publish the stubs and edit them to match your preferred structure:
+## 3. (Optional) Publish stub templates
 
 ```bash
 php artisan vendor:publish --tag=module-generator-stubs
 ```
 
-The command copies every stub to `resources/stubs/module-generator`, where you can update imports, docblocks, method signatures, or any other scaffolding details. The generator will read from your customised stubs on subsequent runs, so your adjustments take effect immediately.
+Stubs are exported to `resources/stubs/module-generator` and override the package defaults on every generation run.【F:src/ModuleGeneratorServiceProvider.php†L41-L49】 Update them to inject traits, logging, or naming conventions that suit your organisation.
 
----
+## 4. Prepare the environment
 
-[← Back to Configuration](../README.md#configuration)
+- Ensure your `.env` database settings are correct. Generated feature tests run against your configured connection instead of forcing SQLite.【F:src/Generators/TestGenerator.php†L19-L44】
+- Commit the published base classes if you plan to customise them—future module runs expect these files to exist.
+- (Laravel 11) keep `bootstrap/providers.php` tracked so provider auto-registration can be committed with each new module.【F:src/Generators/ProviderGenerator.php†L37-L72】
+
+With the prerequisites complete you can jump to the [usage guide](usage.md) for command recipes and inline schema examples.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,80 +1,73 @@
+# Usage
+
 ```bash
 php artisan make:module ModelName [options]
 ```
 
-# Module Generator Usage
+The `make:module` command scaffolds a complete module (model, repository, service, interfaces, DTO, controller, resource, form requests, provider, and tests) with one invocation.【F:src/Commands/MakeModuleCommand.php†L18-L174】
 
-The `make:module` Artisan command scaffolds a fully structured Laravel module (model, repository, service, interfaces, DTO, controller, form requests, resources, and tests) in one step.
+## Options
 
-## Long Options
+| Option | Alias | Description |
+| --- | --- | --- |
+| `--api` | `-a` | Generate an API-oriented controller targeting the configured namespace. |
+| `--controller=Subdir` | `-c` | Place the controller inside a subdirectory (forces controller generation). |
+| `--requests` | `-r` | Generate `Store` and `Update` form requests. |
+| `--tests` | `-t` | Force CRUD feature test generation. |
+| `--no-controller` | `-nc` | Skip controller generation. |
+| `--no-resource` | `-nr` | Skip API Resource generation. |
+| `--no-dto` | `-nd` | Skip DTO generation. |
+| `--no-test` | `-nt` | Skip feature test generation. |
+| `--no-provider` | `-np` | Skip provider creation and automatic registration. |
+| `--from-migration=` | `-fm` | Point to a migration (path or keyword) to infer fields, casts, and relations. |
+| `--fields=` | – | Provide inline schema metadata when migrations are unavailable. |
+| `--force` | `-f` | Overwrite existing files instead of skipping them. |
 
-| Option                | Description |
-|-----------------------|-------------|
-| `--api`               | Generate an API-style controller under the configured API namespace (defaults to `Http/Controllers/Api/V1`). |
-| `--controller=Subdir` | Place the controller inside the specified subdirectory and ensure a controller is generated. |
-| `--requests`          | Generate `Store` and `Update` form request classes. |
-| `--tests`             | Force CRUD Feature Test generation. |
-| `--no-controller`     | Skip controller generation entirely. |
-| `--no-resource`       | Skip API Resource generation. |
-| `--no-dto`            | Skip DTO generation. |
-| `--no-test`           | Skip Feature Test generation. |
-| `--no-provider`       | Skip provider creation and auto-registration. |
-| `--from-migration=`   | Provide a migration path or keyword to infer fields before a model exists. |
-| `--force`             | Overwrite existing files instead of skipping them. |
-| `--fields=`           | Supply an inline schema definition so generators can infer fillable fields, validation rules, and payloads. |
+Defaults are controlled via `config/module-generator.php`. Adjust the `defaults` section to match your common workflow and override per module with CLI flags.【F:src/config/module-generator.php†L37-L52】【F:src/Commands/MakeModuleCommand.php†L64-L132】
 
-## Short Aliases
+## Inline schema DSL (`--fields`)
 
-| Alias | Long option         |
-|-------|---------------------|
-| `-a`  | `--api`             |
-| `-c`  | `--controller`      |
-| `-r`  | `--requests`        |
-| `-t`  | `--tests`           |
-| `-nc` | `--no-controller`   |
-| `-nr` | `--no-resource`     |
-| `-nd` | `--no-dto`          |
-| `-nt` | `--no-test`         |
-| `-np` | `--no-provider`     |
-| `-fm` | `--from-migration`  |
-| `-f`  | `--force`           |
-
-## Sample Scenarios
-
-### API Module with Form Requests and Custom Controller Path
+Use the inline schema option to describe columns before a migration exists:
 
 ```bash
-php artisan make:module Product --api --requests --controller=Admin
+php artisan make:module Product --api --fields="name:string:unique, price:decimal(10,2), user_id:foreign=users.id"
 ```
 
-**Output highlights:**
+- Separate fields with commas.
+- Describe each field as `name:type[:modifier[:modifier...]]`.
+- Supported modifiers include `nullable`, `unique`, and `foreign=table.column` (aliases `fk=` or `references=` work too).【F:src/Support/SchemaParser.php†L9-L138】
 
-- Generates the module skeleton plus a controller at `App/Http/Controllers/Api/V1/Admin/ProductController.php`.
-- Adds `StoreProductRequest` and `UpdateProductRequest` classes with validation rules derived from your schema or `--fields` input.
-- Produces API resources alongside the controller so your endpoints return structured JSON responses.
+The parsed metadata feeds DTOs, resources, validation rules, and feature tests so the generated code aligns with your design from the start.【F:src/Commands/MakeModuleCommand.php†L92-L138】【F:src/Support/MigrationFieldParser.php†L214-L325】
 
-### Full CRUD Module with Tests
+## Migration introspection (`--from-migration`)
+
+When migrations already exist, pass either a full path or a keyword:
 
 ```bash
-php artisan make:module Product --api --requests --controller=Admin --tests
+php artisan make:module Booking --api --requests --from-migration=bookings
 ```
 
-**Output highlights:**
+`MigrationFieldParser` scans the matching migration, extracts columns, relations, casts, defaults, and enum values, and shares the information with downstream generators. It also generates eager-load hints and validation rules for both store and update requests.【F:src/Support/MigrationFieldParser.php†L9-L213】【F:src/Support/MigrationFieldParser.php†L214-L325】
 
-- Everything from the previous scenario.
-- Adds `tests/Feature/ProductCrudTest.php` with happy-path and failure-path scenarios. See the [Feature Tests](../README.md#test-generation) section for details on how these tests are structured.
+If the parser cannot find a migration or field metadata it falls back to inspecting the Eloquent model for fillable attributes and casts, logging helpful warnings in the console.【F:src/Commands/MakeModuleCommand.php†L101-L130】
 
-### Slim Module for Internal Services
+## Controller modes
 
-```bash
-php artisan make:module Report --no-controller --no-resource --no-test
-```
+- `--api` produces a JSON-first controller that wraps responses with `StatusHelper`, supports DTO payloads, and returns API resources when enabled.【F:src/Generators/ControllerGenerator.php†L78-L167】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】
+- Omit `--api` to generate a web controller scaffold that targets Blade views and standard redirect flows.【F:src/Generators/ControllerGenerator.php†L170-L248】
 
-**Output highlights:**
+`--controller=Admin` (or any subpath) forces controller generation and nests the file within the configured namespace.【F:src/Commands/MakeModuleCommand.php†L73-L106】
 
-- Generates core classes (model, repository, service, interfaces, DTO) without any HTTP layer assets.
-- Suitable when the module is consumed internally via services or queued jobs without HTTP endpoints.
+## Feature tests
 
----
+Enable `--tests` (or configure it as default) to generate CRUD feature tests that:
 
-> Re-run the command with `--force` if you need to regenerate files after adjusting your stubs or configuration.
+- Use inferred fillable metadata to build payloads and validation scenarios.
+- Register predictable URIs (e.g., `/test-products`) so you can map them in routes quickly.
+- Cover success and failure paths for store, update, show, index, and destroy actions.【F:src/Generators/TestGenerator.php†L11-L157】
+
+Tests respect your project’s configured database connection—no SQLite swap is forced—so they integrate with existing pipelines seamlessly.【F:src/Generators/TestGenerator.php†L19-L44】
+
+## Regenerating artefacts
+
+When you update configuration or stubs, rerun the command with `--force` to overwrite existing files. The generator reports which files were created or skipped so you have immediate feedback.【F:src/Commands/MakeModuleCommand.php†L117-L174】

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,19 @@
 site_name: Laravel Module Generator Docs
 site_description: Documentation for the Laravel Module Generator package.
-site_url: https://example.com/
-repo_name: laravel-module-generator
-repo_url: https://github.com/example/laravel-module-generator
+site_url: https://efati.github.io/laravel-module-generator/
+repo_name: efati/laravel-module-generator
+repo_url: https://github.com/efati/laravel-module-generator
 nav:
   - Home: index.md
-  - Guides:
+  - Getting Started:
+      - Installation: installation.md
+      - Configuration: configuration.md
+  - Usage: usage.md
+  - Advanced Features: advanced.md
+  - Reference:
+      - Changelog: changelog.md
       - GitHub Pages Setup: github-pages-setup.md
-      - Intelligent Assistant: ia.md
+      - Information Architecture: ia.md
 theme:
   name: readthedocs
 markdown_extensions:

--- a/version.md
+++ b/version.md
@@ -1,1 +1,5 @@
-// version 3.1.0 changes
+// version 6.2.4 summary
+// - Inline schema DSL with nullable/unique/foreign key awareness【F:src/Support/SchemaParser.php†L9-L138】
+// - Migration parser shares validation/cast metadata across generators【F:src/Support/MigrationFieldParser.php†L9-L213】
+// - Provider auto-registration for repositories & services【F:src/Generators/ProviderGenerator.php†L37-L72】
+// - Resources normalise dates/booleans via StatusHelper & Goli helper【F:src/Generators/ResourceGenerator.php†L77-L158】【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】


### PR DESCRIPTION
## Summary
- rewrite the README to highlight the schema-aware generators, Jalali tooling, and release notes for v6.2.4
- expand the MkDocs content (index, installation, usage, configuration, advanced, changelog) to match the 6.2.x capabilities and add a configuration guide
- replace the GitHub Pages workflow with a MkDocs-based build and update navigation, sidebar, and metadata

## Testing
- pip install -r requirements.txt *(fails: repository requires network access to install mkdocs)*
- mkdocs build --strict *(fails: mkdocs not installed because dependencies could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68d6727f5ca48321afd075cf8086cc1e