### PR TITLE
Revamp documentation UI with Material theme

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,0 +1,155 @@
+:root {
+  --md-primary-fg-color: #4c51bf;
+  --md-primary-fg-color--light: #6574cd;
+  --md-primary-fg-color--dark: #3c366b;
+  --md-accent-fg-color: #a3e635;
+}
+
+.md-typeset .hero {
+  display: grid;
+  gap: 2.4rem;
+  padding: 3.5rem clamp(1.5rem, 4vw, 3rem);
+  border-radius: 1.25rem;
+  background: radial-gradient(120% 120% at 90% 10%, rgba(163, 230, 53, 0.18) 0%, rgba(99, 102, 241, 0.85) 45%, rgba(30, 64, 175, 0.95) 100%);
+  color: #f8fafc;
+  position: relative;
+  overflow: hidden;
+}
+
+.md-typeset .hero::after {
+  content: "";
+  position: absolute;
+  inset: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+}
+
+.md-typeset .hero__content {
+  max-width: 42rem;
+  position: relative;
+  z-index: 2;
+}
+
+.md-typeset .hero__title {
+  font-size: clamp(2.25rem, 5vw, 3.4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.75rem;
+}
+
+.md-typeset .hero__lead {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.md-typeset .hero__actions {
+  display: flex;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.md-typeset .hero .md-button {
+  border-radius: 999px;
+  padding-inline: 1.8rem;
+  padding-block: 0.75rem;
+  font-weight: 600;
+}
+
+.md-typeset .hero .md-button--primary {
+  background: rgba(244, 244, 245, 0.15);
+  color: #f8fafc;
+  box-shadow: 0 12px 30px -12px rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+}
+
+.md-typeset .hero .md-button--primary:hover {
+  background: rgba(244, 244, 245, 0.28);
+}
+
+.md-typeset .hero .md-button--secondary {
+  background: rgba(15, 23, 42, 0.25);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.md-typeset .feature-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-block: 2.5rem 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.md-typeset .feature-card {
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(140deg, rgba(248, 250, 252, 0.94), rgba(241, 245, 249, 0.88));
+  box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.5);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .feature-card {
+  background: linear-gradient(140deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.82));
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.md-typeset .feature-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 42px -26px rgba(15, 23, 42, 0.7);
+}
+
+.md-typeset .feature-card h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.md-typeset .quickstart {
+  margin-block: 1rem 3rem;
+  padding: 2rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(79, 70, 229, 0.05);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .quickstart {
+  background: rgba(79, 70, 229, 0.15);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.md-typeset .quickstart h2 {
+  margin-top: 0;
+}
+
+.md-typeset .resource-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.md-typeset .resource-links .md-button {
+  justify-content: space-between;
+  border-radius: 0.85rem;
+  font-weight: 600;
+}
+
+.md-typeset .resource-links .md-button span {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+@media (min-width: 960px) {
+  .md-sidebar--primary {
+    border-right: 1px solid rgba(148, 163, 184, 0.2);
+  }
+}
+
+.md-typeset a {
+  font-weight: 550;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,70 @@
-# Laravel Module Generator
+---
+title: Laravel Module Generator
+hide:
+  - navigation
+---
 
-Welcome to the documentation hub for the **Laravel Module Generator** package. The guides in this site explain how to scaffold opinionated Laravel modules, customise the generated code, and keep the workflow aligned with your team’s conventions.
+<div class="hero">
+  <div class="hero__content">
+    <h1 class="hero__title">Build cohesive Laravel modules in minutes</h1>
+    <p class="hero__lead">Laravel Module Generator bundles migrations, data transfer objects, resources, feature tests, and helper classes so every module ships with the same structure and polish as your best work.</p>
+    <div class="hero__actions">
+      <a class="md-button md-button--primary" href="installation/">Install the package</a>
+      <a class="md-button md-button--secondary" href="usage/">Explore the workflow</a>
+      <a class="md-button" href="https://github.com/efati/laravel-module-generator" target="_blank" rel="noopener">Star on GitHub</a>
+    </div>
+  </div>
+</div>
 
-## Highlights in v6.2.4
+## Why teams choose it
 
-- Schema-aware generation that combines migration introspection and inline `--fields` definitions to hydrate DTOs, validation rules, API resources, and feature tests with a single source of truth.【F:src/Commands/MakeModuleCommand.php†L47-L170】【F:src/Support/MigrationFieldParser.php†L9-L213】
-- Automatic provider registration that binds repositories and services as soon as they are generated, keeping your container in sync.【F:src/Generators/ProviderGenerator.php†L9-L72】
-- Bundled `StatusHelper` and Jalali-aware `Goli` toolkit for consistent API responses and Carbon interoperability out of the box.【F:src/Stubs/Helpers/StatusHelper.php†L1-L83】【F:src/ModuleGeneratorServiceProvider.php†L14-L53】
-- Optional CRUD feature tests that reuse the same metadata to cover happy-path and failure-path scenarios.【F:src/Generators/TestGenerator.php†L11-L157】
+<div class="feature-grid">
+  <div class="feature-card">
+    <h3>:octicons-rows-16: Schema-driven scaffolding</h3>
+    <p>Hydrate DTOs, validation rules, API resources, and feature tests from a single inline schema or by introspecting existing migrations—no more duplicated field metadata.</p>
+  </div>
+  <div class="feature-card">
+    <h3>:octicons-circuit-board-16: Container-aware providers</h3>
+    <p>Repositories and services are registered automatically, keeping your service container in sync with every module you generate.</p>
+  </div>
+  <div class="feature-card">
+    <h3>:octicons-rocket-16: Production-ready defaults</h3>
+    <p>Opinionated stubs ship with API response helpers, Jalali-friendly date handling, and optional CRUD test suites so the generated code feels handcrafted.</p>
+  </div>
+  <div class="feature-card">
+    <h3>:octicons-code-square-16: Extensible stubs</h3>
+    <p>Override any template, wire in custom generators, and tailor namespaces to match the conventions of your organisation.</p>
+  </div>
+</div>
 
-## Quick start
+<div class="quickstart">
+  <h2>Quick start</h2>
+  <p>Install the package and scaffold your first module with tests, resources, and API endpoints in one command.</p>
 
 ```bash
 composer require efati/laravel-module-generator
 php artisan vendor:publish --tag=module-generator
-php artisan make:module Product --api --requests --tests --from-migration=database/migrations/2024_05_01_000000_create_products_table.php
+php artisan make:module Product \
+  --api --requests --tests \
+  --from-migration=database/migrations/2024_05_01_000000_create_products_table.php
 ```
 
-Use `--fields="name:string:unique, price:decimal(10,2)"` when a migration does not exist yet—the inline schema DSL unlocks the same rich metadata for DTOs, resources, and tests.【F:src/Support/SchemaParser.php†L9-L138】
+  <p>Working without a migration yet? Use the inline schema syntax to describe fields once and reuse the metadata everywhere:</p>
 
-## Next steps
+```bash
+php artisan make:module Product --fields="name:string:unique, price:decimal(10,2)"
+```
+</div>
 
-- [Installation](installation.md) – requirements, publishing assets, and environment preparation.
-- [Configuration](configuration.md) – customise namespaces, default toggles, and stub overrides.
-- [Usage](usage.md) – option reference, inline schema recipes, and command examples.
-- [Advanced features](advanced.md) – test scaffolding, Jalali tooling, and extending the generator.
-- [Changelog](changelog.md) – release notes for the 6.x series.
+## Learn more
 
-Need to ship the docs? See the [GitHub Pages guide](github-pages-setup.md) for details on the automated workflow.
+<div class="resource-links">
+  <a class="md-button md-button--primary" href="installation/"><span>:material-download-circle:</span><span>Installation guide</span></a>
+  <a class="md-button md-button--primary" href="configuration/"><span>:material-tune-variant:</span><span>Configuration reference</span></a>
+  <a class="md-button md-button--primary" href="usage/"><span>:material-console:</span><span>Usage &amp; recipes</span></a>
+  <a class="md-button md-button--primary" href="advanced/"><span>:material-lan-connect:</span><span>Advanced features</span></a>
+  <a class="md-button" href="changelog/"><span>:material-newspaper-variant-multiple:</span><span>Changelog</span></a>
+  <a class="md-button" href="github-pages-setup/"><span>:material-github:</span><span>GitHub Pages deployment</span></a>
+</div>
+
+Need to ship the docs? See the <a href="github-pages-setup/">GitHub Pages guide</a> for the automated workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Laravel Module Generator Docs
-site_description: Documentation for the Laravel Module Generator package.
+site_name: Laravel Module Generator
+site_description: Opinionated scaffolding for modular Laravel applications.
 site_url: https://efati.github.io/laravel-module-generator/
 repo_name: efati/laravel-module-generator
 repo_url: https://github.com/efati/laravel-module-generator
@@ -15,9 +15,56 @@ nav:
       - GitHub Pages Setup: github-pages-setup.md
       - Information Architecture: ia.md
 theme:
-  name: readthedocs
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: lime
+    - scheme: slate
+      primary: indigo
+      accent: lime
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+  font:
+    text: "Inter"
+    code: "Fira Code"
+  features:
+    - announce.dismiss
+    - navigation.expand
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - toc.follow
+    - content.action.edit
+    - content.code.annotate
+    - content.code.copy
+    - content.tabs.link
+    - content.tooltips
 markdown_extensions:
-  - toc:
-      permalink: true
-  - tables
   - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.highlight:
+    anchor_linenums: true
+    use_pygments: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink
+  - pymdownx.superfences
+  - tables
+  - toc:
+    permalink: true
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/efati/laravel-module-generator
+      name: GitHub Repository
+extra_css:
+  - assets/stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 mkdocs>=1.5.3
+mkdocs-material>=9.5.0
+pymdown-extensions>=10.7


### PR DESCRIPTION
## Summary
- switch the MkDocs configuration to the Material theme with navigation, typography, and emoji features similar to Laravel Spatie docs
- add a custom stylesheet and refreshed landing page content with hero, feature grid, and resource buttons for a polished presentation
- document the new documentation dependencies required to build the site

## Testing
- `pip install -r requirements.txt` *(fails: proxy prevents downloading mkdocs-material)*

------
https://chatgpt.com/codex/tasks/task_e_68d680169530832194375a994d86ccb4