### PR TITLE
Fix highlight configuration indentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,8 +52,8 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.highlight:
-    anchor_linenums: true
-    use_pygments: true
+      anchor_linenums: true
+      use_pygments: true
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.magiclink


### PR DESCRIPTION
## Summary
- indent the `anchor_linenums` and `use_pygments` options so they remain nested under `pymdownx.highlight`

## Testing
- mkdocs build --strict *(fails: missing `materialx` module because `mkdocs-material` is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6854838c0832199d407a2c2fa5254