### PR TITLE
Add docs landing page and update package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Docs Deployment Status](https://github.com/AfshinEfati/laravel-module-generator/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/AfshinEfati/laravel-module-generator/actions/workflows/docs.yml)
 
+## 📖 Documentation
+
+The full documentation and usage guide is available at:  
+👉 [Laravel Module Generator Docs](https://afshinefati.github.io/laravel-module-generator/)
+
 Generate complete, test-ready Laravel modules from a single Artisan command. The generator scaffolds models, repositories, services, interfaces, DTOs, controllers, API resources, form requests, feature tests, and supporting helpers so you can jump straight to business logic.
 
 > **Compatible with Laravel 10 & 11 · Requires PHP 8.1+**

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "laravel/framework": ">=10.0"
   },
   "keywords": ["laravel", "module-generator", "repository", "service", "crud", "tests"],
-  "homepage": "https://github.com/AfshinEfati/laravel-module-generator",
+  "homepage": "https://afshinefati.github.io/laravel-module-generator/",
   "support": {
     "issues": "https://github.com/AfshinEfati/laravel-module-generator/issues",
     "source": "https://github.com/AfshinEfati/laravel-module-generator"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+title: Laravel Module Generator Documentation
+---
+
+<meta http-equiv="refresh" content="0; url=en/" />
+
+# Redirecting to the documentation
+
+You should be redirected automatically. If not, head over to the [English documentation](en/) or browse the [Persian documentation](fa/).


### PR DESCRIPTION
## Summary
- add a root documentation landing page that redirects to the English locale by default
- point the package homepage to the published documentation site
- surface the documentation link prominently at the top of the README

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ae7596f88321a6cc8801b1c9843a