### PR TITLE
Document interactive vendor publish steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Docs Deployment Status](https://github.com/AfshinEfati/laravel-module-generator/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/AfshinEfati/laravel-module-generator/actions/workflows/docs.yml)
 
+## 📖 Documentation
+
+The full documentation and usage guide is available at:  
+👉 [Laravel Module Generator Docs](https://afshinefati.github.io/laravel-module-generator/)
+
 Generate complete, test-ready Laravel modules from a single Artisan command. The generator scaffolds models, repositories, services, interfaces, DTOs, controllers, API resources, form requests, feature tests, and supporting helpers so you can jump straight to business logic.
 
 > **Compatible with Laravel 10 & 11 · Requires PHP 8.1+**
@@ -25,18 +30,18 @@ Require the package and publish the base assets:
 
 ```bash
 composer require efati/laravel-module-generator
-php artisan vendor:publish --tag=module-generator
+php artisan vendor:publish
 ```
 
-Publishing with the `module-generator` tag installs base repository/service classes, the `StatusHelper`, and `config/module-generator.php` where you can adjust namespaces, paths, and feature toggles.【F:src/ModuleGeneratorServiceProvider.php†L29-L50】【F:src/config/module-generator.php†L5-L53】
+When prompted, choose `Efati\ModuleGenerator\ModuleGeneratorServiceProvider`, then select the `module-generator` tag. This installs the base repository/service classes, the `StatusHelper`, and `config/module-generator.php` where you can adjust namespaces, paths, and feature toggles.【F:src/ModuleGeneratorServiceProvider.php†L29-L50】【F:src/config/module-generator.php†L5-L53】
 
 To customise the stub templates used for every generated file, publish the dedicated stubs once:
 
 ```bash
-php artisan vendor:publish --tag=module-generator-stubs
+php artisan vendor:publish
 ```
 
-The stubs will be copied to `resources/stubs/module-generator`, allowing you to adapt method signatures, imports, or formatting to match your house style.【F:src/ModuleGeneratorServiceProvider.php†L41-L49】
+Pick the same service provider and choose the `module-generator-stubs` tag to copy the templates to `resources/stubs/module-generator`, letting you adapt method signatures, imports, or formatting to match your house style.【F:src/ModuleGeneratorServiceProvider.php†L41-L49】
 
 ## Quick start
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "laravel/framework": ">=10.0"
   },
   "keywords": ["laravel", "module-generator", "repository", "service", "crud", "tests"],
-  "homepage": "https://github.com/AfshinEfati/laravel-module-generator",
+  "homepage": "https://afshinefati.github.io/laravel-module-generator/",
   "support": {
     "issues": "https://github.com/AfshinEfati/laravel-module-generator/issues",
     "source": "https://github.com/AfshinEfati/laravel-module-generator"

--- a/docs/en/advanced.md
+++ b/docs/en/advanced.md
@@ -7,7 +7,7 @@ Customise the generator beyond the defaults to match your organisation.
 
 ## Override stubs per artefact
 
-1. Publish the stubs: `php artisan vendor:publish --tag=module-generator-stubs`.
+1. Publish the stubs by running `php artisan vendor:publish`, selecting `Efati\ModuleGenerator\ModuleGeneratorServiceProvider`, and choosing the `module-generator-stubs` tag.
 2. Edit the templates in `resources/stubs/module-generator`.
 3. Re-run the generator with `--force` to apply your changes.
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,8 +12,8 @@ hide:
     <h1 class="hero__title">Ship consistent Laravel modules without the busywork</h1>
     <p class="hero__lead">Generate controllers, DTOs, services, repositories, requests, and tests from a single artisan command. Every module follows the same structure, so your team can focus on the domain.</p>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="installation.md">Installation guide</a>
-      <a class="md-button md-button--secondary" href="quickstart.md">Run your first module</a>
+      <a class="md-button md-button--primary" href="installation/">Installation guide</a>
+      <a class="md-button md-button--secondary" href="quickstart/">Run your first module</a>
       <a class="md-button" href="https://github.com/AfshinEfati/laravel-module-generator" target="_blank" rel="noopener">View on GitHub</a>
 
     </div>

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -22,10 +22,10 @@ Composer registers `ModuleGeneratorServiceProvider`, which exposes the `make:mod
 ## 2. Publish configuration and helpers
 
 ```bash
-php artisan vendor:publish --tag=module-generator
+php artisan vendor:publish
 ```
 
-This command copies:
+When the interactive prompt appears, select `Efati\ModuleGenerator\ModuleGeneratorServiceProvider` and then the `module-generator` tag. This copies:
 
 - `config/module-generator.php` – adjust namespaces, paths, and default toggles here.
 - Base repository/service classes plus the `StatusHelper` helper used by generated controllers and resources.
@@ -35,10 +35,10 @@ Keep the configuration file under version control so every environment shares th
 ## 3. (Optional) Publish stub templates
 
 ```bash
-php artisan vendor:publish --tag=module-generator-stubs
+php artisan vendor:publish
 ```
 
-Stubs are exported to `resources/stubs/module-generator` and override the package defaults on every generation run. Update them to inject traits, logging, or naming conventions that suit your organisation.
+Choose the same service provider and pick the `module-generator-stubs` tag. Stubs are exported to `resources/stubs/module-generator` and override the package defaults on every generation run. Update them to inject traits, logging, or naming conventions that suit your organisation.
 
 ## 4. Prepare the environment
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -15,11 +15,10 @@ MkDocs build automation is already configured in the repository, so installing t
 ## 2. Publish configuration and stubs (optional)
 
 ```bash
-php artisan vendor:publish --tag=module-generator
-php artisan vendor:publish --tag=module-generator-stubs --force
+php artisan vendor:publish
 ```
 
-The first command publishes the configuration file and helper classes. The second copies the default stubs into `resources/stubs/module-generator` so you can customise controllers, requests, or tests. Re-run the command whenever you pull upstream changes to keep local stubs aligned.
+From the provider list pick `Efati\ModuleGenerator\ModuleGeneratorServiceProvider`, then choose the `module-generator` tag to publish the configuration and helper classes. Run the command again, select the same provider, and choose the `module-generator-stubs` tag (add `--force` if you need to overwrite existing templates). The exported stubs in `resources/stubs/module-generator` let you customise controllers, requests, or tests and can be refreshed after pulling upstream changes.
 
 ## 3. Describe the schema once
 

--- a/docs/fa/advanced.md
+++ b/docs/fa/advanced.md
@@ -9,7 +9,7 @@
 
 ## بازنویسی قالب هر خروجی
 
-1. قالب‌ها را با `php artisan vendor:publish --tag=module-generator-stubs` منتشر کنید.
+1. دستور `php artisan vendor:publish` را اجرا کنید، گزینهٔ `Efati\ModuleGenerator\ModuleGeneratorServiceProvider` را انتخاب کرده و تگ `module-generator-stubs` را برگزینید.
 2. فایل‌های موجود در `resources/stubs/module-generator` را ویرایش کنید.
 3. برای اعمال تغییرات دستور را با فلگ `--force` دوباره اجرا کنید.
 

--- a/docs/fa/index.md
+++ b/docs/fa/index.md
@@ -14,8 +14,8 @@ hide:
     <h1 class="hero__title">بدون کار تکراری ماژول‌های منسجم بسازید</h1>
     <p class="hero__lead">با یک دستور آرتیزان، کنترلر، DTO، سرویس، ریپازیتوری، ریسورس و تست‌های لازم را تولید کنید. ساختار هر ماژول یکسان می‌ماند و تیم روی منطق کسب‌وکار تمرکز می‌کند.</p>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="installation.md">راهنمای نصب</a>
-      <a class="md-button md-button--secondary" href="quickstart.md">اولین ماژول را بسازید</a>
+      <a class="md-button md-button--primary" href="installation/">راهنمای نصب</a>
+      <a class="md-button md-button--secondary" href="quickstart/">اولین ماژول را بسازید</a>
       <a class="md-button" href="https://github.com/AfshinEfati/laravel-module-generator" target="_blank" rel="noopener">مشاهده در گیت‌هاب</a>
 
     </div>

--- a/docs/fa/installation.md
+++ b/docs/fa/installation.md
@@ -24,10 +24,10 @@ composer require efati/laravel-module-generator
 ## ۲. انتشار پیکربندی و کلاس‌های کمکی
 
 ```bash
-php artisan vendor:publish --tag=module-generator
+php artisan vendor:publish
 ```
 
-این دستور موارد زیر را کپی می‌کند:
+در فهرست تعاملی، ابتدا گزینهٔ `Efati\ModuleGenerator\ModuleGeneratorServiceProvider` و سپس تگ `module-generator` را انتخاب کنید. این کار موارد زیر را کپی می‌کند:
 
 - `config/module-generator.php` – نام‌فضاها، مسیر خروجی و پیش‌فرض‌ها را اینجا تنظیم کنید.
 - کلاس‌های پایهٔ سرویس/ریپازیتوری و هِلپر `StatusHelper` که در کنترلرها و ریسورس‌ها استفاده می‌شود.
@@ -37,10 +37,10 @@ php artisan vendor:publish --tag=module-generator
 ## ۳. (اختیاری) انتشار قالب‌ها
 
 ```bash
-php artisan vendor:publish --tag=module-generator-stubs
+php artisan vendor:publish
 ```
 
-قالب‌ها در مسیر `resources/stubs/module-generator` قرار می‌گیرند و از این پس جایگزین نسخهٔ بسته می‌شوند. آن‌ها را ویرایش کنید تا تریت‌ها، لاگ یا استانداردهای نام‌گذاری سازمان شما اعمال شود.
+همان سرویس‌پرووایدر را انتخاب کنید و این بار تگ `module-generator-stubs` را برگزینید. قالب‌ها در مسیر `resources/stubs/module-generator` قرار می‌گیرند و از این پس جایگزین نسخهٔ بسته می‌شوند. آن‌ها را ویرایش کنید تا تریت‌ها، لاگ یا استانداردهای نام‌گذاری سازمان شما اعمال شود.
 
 ## ۴. آماده‌سازی محیط
 

--- a/docs/fa/quickstart.md
+++ b/docs/fa/quickstart.md
@@ -18,11 +18,10 @@ composer require efati/laravel-module-generator
 ## ۲. انتشار تنظیمات و قالب‌ها (اختیاری)
 
 ```bash
-php artisan vendor:publish --tag=module-generator
-php artisan vendor:publish --tag=module-generator-stubs --force
+php artisan vendor:publish
 ```
 
-دستور اول فایل پیکربندی و کلاس‌های کمکی را منتشر می‌کند. دستور دوم قالب‌های پیش‌فرض را در مسیر `resources/stubs/module-generator` قرار می‌دهد تا بتوانید کنترلر، ریکوئست یا تست‌ها را شخصی‌سازی کنید. هر زمان تغییرات upstream را دریافت کردید دوباره دستور را اجرا کنید تا قالب‌ها همگام شوند.
+از فهرست، گزینهٔ `Efati\ModuleGenerator\ModuleGeneratorServiceProvider` و سپس تگ `module-generator` را برای انتشار فایل پیکربندی و کلاس‌های کمکی انتخاب کنید. دستور را دوباره اجرا کنید، همان سرویس‌پرووایدر را برگزینید و این بار تگ `module-generator-stubs` را انتخاب کنید (در صورت نیاز برای بازنویسی قالب‌های موجود، فلگ `--force` را اضافه کنید). قالب‌های کپی‌شده در `resources/stubs/module-generator` امکان شخصی‌سازی کنترلر، ریکوئست یا تست‌ها را فراهم می‌کنند و پس از دریافت تغییرات upstream می‌توانید آن‌ها را تازه‌سازی کنید.
 
 ## ۳. فقط یک بار اسکیما را توصیف کنید
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+title: Laravel Module Generator Documentation
+---
+
+<meta http-equiv="refresh" content="0; url=en/" />
+
+# Redirecting to the documentation
+
+You should be redirected automatically. If not, head over to the [English documentation](en/) or browse the [Persian documentation](fa/).


### PR DESCRIPTION
## Summary
- update the README and English installation guides to explain selecting the Module Generator service provider and tag during `vendor:publish`
- mirror the interactive vendor publish guidance across the Persian installation, quickstart, and advanced docs
- clarify stub publishing instructions in both languages to pick the `module-generator-stubs` tag from the prompt

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d6ae7596f88321a6cc8801b1c9843a