### PR TITLE
Automate module generator asset publishing

### DIFF
--- a/src/ModuleGeneratorServiceProvider.php
+++ b/src/ModuleGeneratorServiceProvider.php
@@ -5,6 +5,7 @@ namespace Efati\ModuleGenerator;
 use Carbon\Carbon;
 use DateTimeZone;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Filesystem\Filesystem;
 use Efati\ModuleGenerator\Commands\MakeModuleCommand;
 use Efati\ModuleGenerator\Support\Goli;
 
@@ -33,21 +34,57 @@ class ModuleGeneratorServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->publishes([
+        $defaultPublishables = [
             __DIR__ . '/Stubs/BaseRepository.php'           => app_path('Repositories/Eloquent/BaseRepository.php'),
             __DIR__ . '/Stubs/BaseRepositoryInterface.php'  => app_path('Repositories/Contracts/BaseRepositoryInterface.php'),
             __DIR__ . '/Stubs/BaseService.php'              => app_path('Services/BaseService.php'),
             __DIR__ . '/Stubs/BaseServiceInterface.php'     => app_path('Services/Contracts/BaseServiceInterface.php'),
             __DIR__ . '/config/module-generator.php'        => config_path('module-generator.php'),
             __DIR__ . '/Stubs/Helpers/StatusHelper.php'     => app_path('Helpers/StatusHelper.php'),
-        ], 'module-generator');
+        ];
+
+        $this->publishes($defaultPublishables, 'module-generator');
 
         $resourceStubPath = function_exists('resource_path')
             ? resource_path('stubs/module-generator')
             : app()->resourcePath('stubs/module-generator');
 
-        $this->publishes([
+        $stubPublishables = [
             __DIR__ . '/Stubs/Module' => $resourceStubPath,
-        ], 'module-generator-stubs');
+        ];
+
+        $this->publishes($stubPublishables, 'module-generator-stubs');
+
+        if ($this->app->runningInConsole()) {
+            $this->ensurePublished($defaultPublishables + $stubPublishables);
+        }
+    }
+
+    protected function ensurePublished(array $paths): void
+    {
+        /** @var \Illuminate\Filesystem\Filesystem $filesystem */
+        $filesystem = $this->app->make(Filesystem::class);
+
+        foreach ($paths as $from => $to) {
+            if (is_dir($from)) {
+                if (! $filesystem->isDirectory($to)) {
+                    $filesystem->copyDirectory($from, $to);
+                }
+
+                continue;
+            }
+
+            if ($filesystem->exists($to)) {
+                continue;
+            }
+
+            $directory = dirname($to);
+
+            if (! $filesystem->isDirectory($directory)) {
+                $filesystem->makeDirectory($directory, 0755, true);
+            }
+
+            $filesystem->copy($from, $to);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add filesystem dependency to the service provider to mirror the vendor publish assets automatically
- ensure module generator configuration and stub assets are copied on console boot without requiring an explicit vendor:publish command

## Testing
- composer test *(fails: Command "test" is not defined.)*
- vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dc04a6e49c8321998a72681bb249b6