### PR TITLE
Infer fillable fields from database columns

### DIFF
--- a/src/Generators/DTOGenerator.php
+++ b/src/Generators/DTOGenerator.php
@@ -3,6 +3,7 @@
 namespace Efati\ModuleGenerator\Generators;
 
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
+use Efati\ModuleGenerator\Support\ModelInspector;
 use Efati\ModuleGenerator\Support\Stub;
 
 use Illuminate\Support\Facades\File;
@@ -42,27 +43,7 @@ class DTOGenerator
     private static function getFillable(string $modelFqcn): array
 
     {
-        if (!class_exists($modelFqcn)) {
-            return [];
-        }
-
-        $model = new $modelFqcn();
-
-        if (method_exists($model, 'getFillable')) {
-            $fillable = (array) $model->getFillable();
-            if (!empty($fillable)) {
-                return array_values($fillable);
-            }
-        }
-
-        if (property_exists($model, 'fillable') && is_array($model->fillable)) {
-            $fillable = array_filter($model->fillable, fn ($value) => is_string($value) && $value !== '');
-            if (!empty($fillable)) {
-                return array_values($fillable);
-            }
-        }
-
-        return [];
+        return ModelInspector::extractFillable($modelFqcn);
     }
 
     private static function build(string $className, string $baseNamespace, array $fillable): string

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -5,6 +5,7 @@ namespace Efati\ModuleGenerator\Generators;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
+use Efati\ModuleGenerator\Support\ModelInspector;
 use Efati\ModuleGenerator\Support\SchemaParser;
 use Efati\ModuleGenerator\Support\Stub;
 
@@ -71,11 +72,7 @@ class FormRequestGenerator
             }
         }
 
-        $fillable = [];
-        if (class_exists($modelFqcn)) {
-            $m = new $modelFqcn();
-            $fillable = method_exists($m, 'getFillable') ? (array) $m->getFillable() : [];
-        }
+        $fillable = ModelInspector::extractFillable($modelFqcn);
 
         if (empty($fillable) && !empty($schema)) {
             $fillable = SchemaParser::fieldNames($schema);

--- a/src/Generators/ResourceGenerator.php
+++ b/src/Generators/ResourceGenerator.php
@@ -3,6 +3,7 @@
 namespace Efati\ModuleGenerator\Generators;
 
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
+use Efati\ModuleGenerator\Support\ModelInspector;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -60,11 +61,7 @@ class ResourceGenerator
 
     private static function getFillable(string $modelFqcn): array
     {
-        if (!class_exists($modelFqcn)) {
-            return [];
-        }
-        $m = new $modelFqcn();
-        return method_exists($m, 'getFillable') ? $m->getFillable() : [];
+        return ModelInspector::extractFillable($modelFqcn);
     }
 
     private static function getModelCasts(string $modelFqcn): array

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -3,6 +3,7 @@
 namespace Efati\ModuleGenerator\Generators;
 
 use Efati\ModuleGenerator\Support\MigrationFieldParser;
+use Efati\ModuleGenerator\Support\ModelInspector;
 use Efati\ModuleGenerator\Support\Stub;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -169,13 +170,7 @@ class TestGenerator
 
     private static function getFillable(string $modelFqcn): array
     {
-        if (!class_exists($modelFqcn)) {
-            return [];
-        }
-
-        $model = new $modelFqcn();
-
-        return method_exists($model, 'getFillable') ? $model->getFillable() : [];
+        return ModelInspector::extractFillable($modelFqcn);
     }
 
     private static function exportArray(array $arr): string

--- a/src/Support/ModelInspector.php
+++ b/src/Support/ModelInspector.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Efati\ModuleGenerator\Support;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class ModelInspector
+{
+    /**
+     * Attempt to determine the model fields that should be treated as fillable.
+     */
+    public static function extractFillable(string $modelFqcn): array
+    {
+        if (!class_exists($modelFqcn)) {
+            return [];
+        }
+
+        $model = new $modelFqcn();
+
+        $fillable = [];
+        if (method_exists($model, 'getFillable')) {
+            $fillable = array_filter((array) $model->getFillable(), static fn ($value) => is_string($value) && $value !== '');
+            if (!empty($fillable)) {
+                return array_values(array_unique($fillable));
+            }
+        }
+
+        if (property_exists($model, 'fillable') && is_array($model->fillable)) {
+            $fillable = array_filter($model->fillable, static fn ($value) => is_string($value) && $value !== '');
+            if (!empty($fillable)) {
+                return array_values(array_unique($fillable));
+            }
+        }
+
+        return self::extractColumnsFromModel($model);
+    }
+
+    private static function extractColumnsFromModel(object $model): array
+    {
+        if (!$model instanceof EloquentModel) {
+            return [];
+        }
+
+        if (!method_exists($model, 'getConnection') || !method_exists($model, 'getTable')) {
+            return [];
+        }
+
+        try {
+            $connection = $model->getConnection();
+            if ($connection === null) {
+                return [];
+            }
+
+            $schema = $connection->getSchemaBuilder();
+            if ($schema === null) {
+                return [];
+            }
+
+            $columns = $schema->getColumnListing($model->getTable());
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        $columns = array_filter($columns, static fn ($value) => is_string($value) && $value !== '');
+
+        return array_values(array_unique($columns));
+    }
+}


### PR DESCRIPTION
## Summary
- add a model inspector helper that falls back to database column discovery when fillable attributes are not configured
- update DTO, resource, form request, and test generators to use the new helper so generated artifacts include model columns even without fillable definitions

## Testing
- not run (phpunit binary not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68e624f23cac83219cca105911f4387a